### PR TITLE
melee attack-range leeway mechanic

### DIFF
--- a/src/game/Objects/Object.h
+++ b/src/game/Objects/Object.h
@@ -172,7 +172,7 @@ enum MovementFlags
     MOVEFLAG_HOVER              = 0x40000000,
     MOVEFLAG_INTERNAL           = 0x80000000,
 
-    // Nostalrius : ne peut etre present avec MOVEFLAG_ROOT (freez client sinon)
+    // Nostalrius : Can not be present with MOVEFLAG_ROOT (otherwise client freeze)
     MOVEFLAG_MASK_MOVING        =
         MOVEFLAG_FORWARD | MOVEFLAG_BACKWARD | MOVEFLAG_STRAFE_LEFT | MOVEFLAG_STRAFE_RIGHT |
         MOVEFLAG_PITCH_UP | MOVEFLAG_PITCH_DOWN | MOVEFLAG_JUMPING | MOVEFLAG_FALLINGFAR |

--- a/src/game/Objects/Object.h
+++ b/src/game/Objects/Object.h
@@ -788,6 +788,7 @@ class MANGOS_DLL_SPEC WorldObject : public Object
         bool IsFlying() const { return m_movementInfo.HasMovementFlag(MOVEFLAG_FLYING);}
         bool IsWalking() const { return m_movementInfo.HasMovementFlag(MOVEFLAG_WALK_MODE);}
         bool IsMoving() const { return m_movementInfo.HasMovementFlag(MOVEFLAG_MASK_MOVING);}
+        bool IsSwimming() const { return m_movementInfo.HasMovementFlag(MOVEFLAG_SWIMMING); }
 
         MovementInfo m_movementInfo;
         Transport * m_transport;

--- a/src/game/Objects/Unit.cpp
+++ b/src/game/Objects/Unit.cpp
@@ -10453,10 +10453,10 @@ float Unit::GetCombatReach(Unit const* pVictim, bool forMeleeRange /*=true*/, fl
 	MOVEFLAG_FORWARD | MOVEFLAG_BACKWARD |
 	MOVEFLAG_STRAFE_LEFT | MOVEFLAG_STRAFE_RIGHT;
 			
-	if (!u->HasUnitMovementFlag(moveflag_mask_xz))
-	{
-		sLog.outBasic("NOT MOVING");
-		return 0.0f;
+		if (!u->HasUnitMovementFlag(moveflag_mask_xz))
+		{
+			sLog.outBasic("NOT MOVING");
+			return 0.0f;
 		}
 		if (u->IsSwimming())
 		{

--- a/src/game/Objects/Unit.cpp
+++ b/src/game/Objects/Unit.cpp
@@ -10421,10 +10421,12 @@ float Unit::GetCombatReach(Unit const* pVictim, bool forMeleeRange /*=true*/, fl
 	//Melee leeway mechanic.
 	//When both player and target has > 70% of normal runspeed, and are moving,
 	//the player gains an additional 2.5yd of melee range.
-	if (this->IsPlayer()) {
+	if (this->IsPlayer()) 
+	{
 		if (this->GetSpeedRate(UnitMoveType::MOVE_RUN) > 0.7f
 			&& pVictim->GetSpeedRate(UnitMoveType::MOVE_RUN) > 0.7f
-			&& this->IsMoving() && pVictim->IsMoving()) {
+			&& this->IsMoving() && pVictim->IsMoving()) 
+		{
 			reach += 2.5f;
 		}
 	}

--- a/src/game/Objects/Unit.cpp
+++ b/src/game/Objects/Unit.cpp
@@ -10418,6 +10418,17 @@ float Unit::GetCombatReach(Unit const* pVictim, bool forMeleeRange /*=true*/, fl
 			reach = ATTACK_DISTANCE;
 	}
 
+	//Melee leeway mechanic.
+	//When both player and target has > 70% of normal runspeed, and are moving,
+	//the player gains an additional 2.5yd of melee range.
+	if (this->IsPlayer()) {
+		if (this->GetSpeedRate(UnitMoveType::MOVE_RUN) > 0.7f
+			&& pVictim->GetSpeedRate(UnitMoveType::MOVE_RUN) > 0.7f
+			&& this->IsMoving() && pVictim->IsMoving()) {
+			reach += 2.5f;
+		}
+	}
+
 	return reach;
 }
 

--- a/src/game/Spells/Spell.cpp
+++ b/src/game/Spells/Spell.cpp
@@ -6120,14 +6120,7 @@ SpellCastResult Spell::CheckRange(bool strict)
                 // Nostalrius : requiert cible devant pour ces sorts !
                 if (!m_caster->HasInArc(M_PI_F, target))
                     return SPELL_FAILED_UNIT_NOT_INFRONT;
-                float range_mod = strict ? 1.25f : 6.25f;
-                // Mouvements -> desync
-                if (m_caster->IsPlayer())
-                    if (m_caster->IsMoving())
-                        range_mod += 1.5f;
-                if (target->IsPlayer())
-                    if (target->IsMoving())
-                        range_mod += 1.5f;
+                float range_mod = 1.0f;
 
                 float base = ATTACK_DISTANCE;
                 if (Player* modOwner = m_caster->GetSpellModOwner())


### PR DESCRIPTION
In reference to: https://elysium-project.org/bugtracker/issue/2307

It should work for player vs player and player vs npc. I'm not sure if this mechanic should work for npcs vs players as well (e.g if a mob is chasing a player), so I ignored that.

