### PR TITLE
Fix for ritual part of RFD escort.

### DIFF
--- a/sql/migrations/20170312073355_world.sql
+++ b/sql/migrations/20170312073355_world.sql
@@ -1,0 +1,5 @@
+INSERT INTO `migrations` VALUES ('20170312073355'); 
+-- FIX for Extinguishing the Idol quest, where involverelation entry is missing for brazier
+
+-- Allow quest to be turned in to Belnistrasz's Brazier
+INSERT INTO `gameobject_involvedrelation` VALUES ('152097','3525')

--- a/sql/migrations/20170312073355_world.sql
+++ b/sql/migrations/20170312073355_world.sql
@@ -1,5 +1,5 @@
 INSERT INTO `migrations` VALUES ('20170312073355'); 
--- FIX for Extinguishing the Idol quest, where involverelation entry is missing for brazier
+-- FIX for Extinguishing the Idol quest, where involvedrelation entry is missing for brazier
 
 -- Allow quest to be turned in to Belnistrasz's Brazier
 INSERT INTO `gameobject_involvedrelation` VALUES ('152097','3525')

--- a/src/scripts/kalimdor/the_barrens/razorfen_downs/razorfen_downs.cpp
+++ b/src/scripts/kalimdor/the_barrens/razorfen_downs/razorfen_downs.cpp
@@ -157,6 +157,7 @@ enum
     SPELL_FIREBALL = 9053,
     SPELL_FROST_NOVA = 11831,
     SPELL_IDOL_SHUTDOWN = 12774,
+    SPELL_ROOT_SELF = 23973,
 
     // summon spells only exist in 1.x
     //SPELL_SUMMON_1 = 12694, // NPC_WITHERED_BATTLE_BOAR
@@ -272,7 +273,7 @@ struct npc_belnistraszAI : public npc_escortAI
                 switch (m_uiRitualPhase)
                 {
                     case 0:
-                        DoCast(m_creature, 23973, true); // roots self so he stays put while channeling
+                        DoCast(m_creature, SPELL_ROOT_SELF, true); // roots self so he stays put while channeling
                         DoCastSpellIfCan(m_creature, SPELL_IDOL_SHUTDOWN);
                         m_uiRitualTimer = 1000;
                         break;

--- a/src/scripts/kalimdor/the_barrens/razorfen_downs/razorfen_downs.cpp
+++ b/src/scripts/kalimdor/the_barrens/razorfen_downs/razorfen_downs.cpp
@@ -272,6 +272,7 @@ struct npc_belnistraszAI : public npc_escortAI
                 switch (m_uiRitualPhase)
                 {
                     case 0:
+                        DoCast(m_creature, 23973, true); // roots self so he stays put while channeling
                         DoCastSpellIfCan(m_creature, SPELL_IDOL_SHUTDOWN);
                         m_uiRitualTimer = 1000;
                         break;
@@ -317,16 +318,9 @@ struct npc_belnistraszAI : public npc_escortAI
                         if (Player* pPlayer = GetPlayerForEscort())
                         {
                             pPlayer->GroupEventHappens(QUEST_EXTINGUISHING_THE_IDOL, m_creature);
-                            if (GameObject* pGo = GetClosestGameObjectWithEntry(m_creature, GO_BELNISTRASZ_BRAZIER, 10.0f))
-                            {
-                                if (!pGo->isSpawned())
-                                {
-                                    pGo->SetRespawnTime(HOUR * IN_MILLISECONDS);
-                                    pGo->Refresh();
-                                }
-                            }
                         }
                         m_creature->RemoveAurasDueToSpell(SPELL_IDOL_SHUTDOWN);
+                        m_creature->SummonGameObject(GO_BELNISTRASZ_BRAZIER, 2577.196f, 947.0781f, 53.16757f, 2.356195f, 0, 0, 0.9238796f, 0.3826832f, 3600);
                         SetEscortPaused(false);
                         break;
                     }
@@ -357,7 +351,8 @@ struct npc_belnistraszAI : public npc_escortAI
         else
             m_uiFrostNovaTimer -= uiDiff;
 
-        DoMeleeAttackIfReady();
+        if (!HasEscortState(STATE_ESCORT_PAUSED))
+            DoMeleeAttackIfReady();
     }
 
 };


### PR DESCRIPTION
Currently on Elysium there are some bugs in the ritual script for the quest Extinguishing the Idol in RFD. Belnistrasz chases mobs while he is supposed to be channeling his ritual spell, and when the event is complete he doesn't spawn the gameobject "Belnistrasz's Brazier", so you can't turn in the quest. This commit resolves these bugs.