### PR TITLE
Add missing CMakeLists for extractors

### DIFF
--- a/contrib/CMakeLists.txt
+++ b/contrib/CMakeLists.txt
@@ -1,0 +1,28 @@
+# Copyright (C) 2005-2011 MaNGOS <http://getmangos.com/>
+# Copyright (C) 2009-2011 MaNGOSZero <https://github.com/mangos/zero>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+# Needs to link against mangos_world.lib
+if(WIN32)
+  include_directories(
+    ${CMAKE_SOURCE_DIR}/dep/include # For Win32
+  )
+endif()
+
+add_subdirectory(extractor)
+add_subdirectory(mmap)
+add_subdirectory(vmap_assembler)
+add_subdirectory(vmap_extractor)

--- a/dep/libmpq/CMakeLists.txt
+++ b/dep/libmpq/CMakeLists.txt
@@ -1,0 +1,28 @@
+# Copyright (C) 2005-2011 MaNGOS <http://getmangos.com/>
+# Copyright (C) 2009-2011 MaNGOSZero <https://github.com/mangos/zero>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+cmake_minimum_required(VERSION 3.0)
+project(libmpq)
+
+include_directories(${CMAKE_CURRENT_SOURCE_DIR})
+include_directories(${CMAKE_CURRENT_SOURCE_DIR}/libmpq)
+include_directories(${CMAKE_SOURCE_DIR}/dep/src/bzip2)
+include_directories(${CMAKE_SOURCE_DIR}/dep/src/zlib)
+
+file(GLOB mpqfiles libmpq/*.c libmpq/*.h *.h)
+
+add_library(libmpq ${mpqfiles})


### PR DESCRIPTION
Project can now be successfully configured to include extractors, and they can be compiled straight away without needing to specify any include directories manually.