### PR TITLE
EventProcessor::GetEvents should return const reference instead of value

### DIFF
--- a/src/framework/Utilities/EventProcessor.h
+++ b/src/framework/Utilities/EventProcessor.h
@@ -85,7 +85,7 @@ class EventProcessor
 
         // Zerix: Nostalrius compatibility. Figure a better way to handle this.
         bool HasScheduledEvent() const { return m_events.empty() ? false : true; }
-        EventList GetEvents() const { return m_events; }
+        EventList const& GetEvents() const { return m_events; }
 
     protected:
         uint64 m_time;


### PR DESCRIPTION
In reference to comment on issue #58 
I don't know this piece of code, so someone should check if the fix can cause other issues, but it does prevent the server from crashing when player changes map.