### PR TITLE
Make general channels multi-language

### DIFF
--- a/src/game/Chat/Channel.cpp
+++ b/src/game/Chat/Channel.cpp
@@ -25,12 +25,12 @@
 #include "SocialMgr.h"
 #include "MasterPlayer.h"
 
-Channel::Channel(const std::string& name)
+Channel::Channel(const std::string& name, const std::string& originalName, LocaleConstant locale)
     : m_announce(true), m_moderate(false), m_name(name), m_flags(0), m_channelId(0),
         m_securityLevel(0), m_area_dependant(true), m_levelRestricted(true)
 {
     // set special flags if built-in channel
-    ChatChannelsEntry const* ch = GetChannelEntryFor(name);
+    ChatChannelsEntry const* ch = GetChannelEntryFor(originalName);
     if (ch)                                                 // it's built-in channel
     {
         m_channelId = ch->ChannelID;                        // only built-in channel have channel id != 0
@@ -51,6 +51,8 @@ Channel::Channel(const std::string& name)
             m_flags |= CHANNEL_FLAG_LFG;
         else                                                // for all other channels
             m_flags |= CHANNEL_FLAG_NOT_LFG;
+        m_localized_names = new std::string[MAX_DBC_LOCALE];
+        m_localized_names[locale] = originalName;
     }
     else                                                    // it's custom channel
     {
@@ -73,14 +75,34 @@ Channel::Channel(const std::string& name)
     }
 }
 
-void Channel::Join(ObjectGuid p, const char *pass)
+Channel::~Channel()
+{
+    if (m_channelId != 0)
+        delete[] m_localized_names;
+}
+
+void Channel::SetLocalName(LocaleConstant locale, std::string localname)
+{
+    if (m_channelId != 0)
+        m_localized_names[locale] = localname;
+}
+
+std::string Channel::GetLocalName(LocaleConstant locale)
+{
+    if (m_channelId != 0)
+        return m_localized_names[locale];
+    else
+        return "";
+}
+
+void Channel::Join(ObjectGuid p, const char* name, const char *pass)
 {
     WorldPacket data;
     if (IsOn(p))
     {
         if (!IsConstant())                                  // non send error message for built-in channels
         {
-            MakePlayerAlreadyMember(&data, p);
+            MakePlayerAlreadyMember(&data, p, name);
             SendToOne(&data, p);
         }
         return;
@@ -88,14 +110,14 @@ void Channel::Join(ObjectGuid p, const char *pass)
 
     if (IsBanned(p))
     {
-        MakeBanned(&data);
+        MakeBanned(&data, name);
         SendToOne(&data, p);
         return;
     }
 
     if (m_password.length() > 0 && strcmp(pass, m_password.c_str()))
     {
-        MakeWrongPassword(&data);
+        MakeWrongPassword(&data, name);
         SendToOne(&data, p);
         return;
     }
@@ -104,13 +126,24 @@ void Channel::Join(ObjectGuid p, const char *pass)
 
     if (m_securityLevel && (!plr.get() || plr->GetSession()->GetSecurity() < m_securityLevel))
     {
-        MakeWrongPassword(&data);
+        MakeWrongPassword(&data, name);
         SendToOne(&data, p);
         return;
     }
 
     if (plr && plr->ToPlayer())
     {
+        if (GetChannelId() == CHANNEL_ID_TRADE || GetChannelId() == CHANNEL_ID_GUILD_RECRUITMENT)
+        {
+            uint32 zoneid = GetAreaIdByLocalizedName(name);
+            if (zoneid != CAPITAL_ZONE_ID)
+            {
+                sLog.outError("Player \"%s\" tried to join channel \"%s\" without beeing in a capital city: zoneid=%u", plr->GetName(), name, zoneid);
+                return;
+            }
+        }
+
+        SetLocalName(plr->GetSession()->GetSessionDbcLocale(), name);
         if (plr->GetGuildId() && (GetFlags() == 0x38))
             return;
 
@@ -119,7 +152,7 @@ void Channel::Join(ObjectGuid p, const char *pass)
 
     if (m_announce && (!plr.get() || plr->GetSession()->GetSecurity() < SEC_GAMEMASTER || !sWorld.getConfig(CONFIG_BOOL_SILENTLY_GM_JOIN_TO_CHANNEL)))
     {
-        MakeJoined(&data, p);
+        MakeJoined(&data, p, name);
         SendToAll(&data);
     }
 
@@ -127,29 +160,29 @@ void Channel::Join(ObjectGuid p, const char *pass)
 
     PlayerInfo& pinfo = m_players[p];
     pinfo.player = p;
-    pinfo.flags = 0;
+    pinfo.flags = MEMBER_FLAG_NONE;
 
-    MakeYouJoined(&data);
+    MakeYouJoined(&data, name);
     SendToOne(&data, p);
 
-    JoinNotify(p);
+    JoinNotify(p, name);
 
     // if no owner first logged will become
     if (HasFlag(CHANNEL_FLAG_CUSTOM) && !IsConstant() && !m_ownerGuid)
     {
-        SetOwner(p, (m_players.size() > 1 ? true : false));
+        SetOwner(p, name, (m_players.size() > 1 ? true : false));
         m_players[p].SetModerator(true);
     }
 }
 
-void Channel::Leave(ObjectGuid p, bool send)
+void Channel::Leave(ObjectGuid p, const char* name, bool send)
 {
     if (!IsOn(p))
     {
         if (send)
         {
             WorldPacket data;
-            MakeNotMember(&data);
+            MakeNotMember(&data, name);
             SendToOne(&data, p);
         }
     }
@@ -160,7 +193,7 @@ void Channel::Leave(ObjectGuid p, bool send)
         if (send)
         {
             WorldPacket data;
-            MakeYouLeft(&data);
+            MakeYouLeft(&data, name);
             SendToOne(&data, p);
             plr->LeftChannel(this);
             data.clear();
@@ -172,21 +205,21 @@ void Channel::Leave(ObjectGuid p, bool send)
         if (m_announce && (!plr.get() || plr->GetSession()->GetSecurity() < SEC_GAMEMASTER || !sWorld.getConfig(CONFIG_BOOL_SILENTLY_GM_JOIN_TO_CHANNEL)))
         {
             WorldPacket data;
-            MakeLeft(&data, p);
+            MakeLeft(&data, p, name);
             SendToAll(&data);
         }
 
-        LeaveNotify(p);
+        LeaveNotify(p, name);
 
         if (changeowner)
         {
             ObjectGuid newowner = !m_players.empty() ? m_players.begin()->second.player : ObjectGuid();
-            SetOwner(newowner);
+            SetOwner(newowner, name);
         }
     }
 }
 
-void Channel::KickOrBan(ObjectGuid good, const char *badname, bool ban)
+void Channel::KickOrBan(ObjectGuid good, const char *badname, bool ban, const char *chanName)
 {
     AccountTypes sec = SEC_PLAYER;
     PlayerPointer gplr = GetPlayer(good);
@@ -196,13 +229,13 @@ void Channel::KickOrBan(ObjectGuid good, const char *badname, bool ban)
     if (!IsOn(good))
     {
         WorldPacket data;
-        MakeNotMember(&data);
+        MakeNotMember(&data, chanName);
         SendToOne(&data, good);
     }
     else if (!m_players[good].IsModerator() && sec < SEC_GAMEMASTER)
     {
         WorldPacket data;
-        MakeNotModerator(&data);
+        MakeNotModerator(&data, chanName);
         SendToOne(&data, good);
     }
     else
@@ -211,13 +244,13 @@ void Channel::KickOrBan(ObjectGuid good, const char *badname, bool ban)
         if (bad == NULL || !IsOn(bad->GetObjectGuid()))
         {
             WorldPacket data;
-            MakePlayerNotFound(&data, badname);
+            MakePlayerNotFound(&data, badname, chanName);
             SendToOne(&data, good);
         }
         else if (sec < SEC_GAMEMASTER && bad->GetObjectGuid() == m_ownerGuid && good != m_ownerGuid)
         {
             WorldPacket data;
-            MakeNotOwner(&data);
+            MakeNotOwner(&data, chanName);
             SendToOne(&data, good);
         }
         else
@@ -229,10 +262,10 @@ void Channel::KickOrBan(ObjectGuid good, const char *badname, bool ban)
             if (ban && !IsBanned(bad->GetObjectGuid()))
             {
                 m_banned.insert(bad->GetObjectGuid());
-                MakePlayerBanned(&data, bad->GetObjectGuid(), good);
+                MakePlayerBanned(&data, bad->GetObjectGuid(), good, chanName);
             }
             else
-                MakePlayerKicked(&data, bad->GetObjectGuid(), good);
+                MakePlayerKicked(&data, bad->GetObjectGuid(), good, chanName);
 
             SendToAll(&data);
             m_players.erase(bad->GetObjectGuid());
@@ -241,13 +274,13 @@ void Channel::KickOrBan(ObjectGuid good, const char *badname, bool ban)
             if (changeowner)
             {
                 ObjectGuid newowner = !m_players.empty() ? good : ObjectGuid();
-                SetOwner(newowner);
+                SetOwner(newowner, chanName);
             }
         }
     }
 }
 
-void Channel::UnBan(ObjectGuid good, const char *badname)
+void Channel::UnBan(ObjectGuid good, const char *badname, const char *chanName)
 {
     uint32 sec = 0;
     PlayerPointer gplr = GetPlayer(good);
@@ -257,13 +290,13 @@ void Channel::UnBan(ObjectGuid good, const char *badname)
     if (!IsOn(good))
     {
         WorldPacket data;
-        MakeNotMember(&data);
+        MakeNotMember(&data, chanName);
         SendToOne(&data, good);
     }
     else if (!m_players[good].IsModerator() && sec < SEC_GAMEMASTER)
     {
         WorldPacket data;
-        MakeNotModerator(&data);
+        MakeNotModerator(&data, chanName);
         SendToOne(&data, good);
     }
     else
@@ -272,7 +305,7 @@ void Channel::UnBan(ObjectGuid good, const char *badname)
         if (bad == NULL || !IsBanned(bad->GetObjectGuid()))
         {
             WorldPacket data;
-            MakePlayerNotFound(&data, badname);
+            MakePlayerNotFound(&data, badname, chanName);
             SendToOne(&data, good);
         }
         else
@@ -280,13 +313,13 @@ void Channel::UnBan(ObjectGuid good, const char *badname)
             m_banned.erase(bad->GetObjectGuid());
 
             WorldPacket data;
-            MakePlayerUnbanned(&data, bad->GetObjectGuid(), good);
+            MakePlayerUnbanned(&data, bad->GetObjectGuid(), good, chanName);
             SendToAll(&data);
         }
     }
 }
 
-void Channel::Password(ObjectGuid p, const char *pass)
+void Channel::Password(ObjectGuid p, const char *pass, const char *chanName)
 {
     uint32 sec = 0;
     PlayerPointer plr = GetPlayer(p);
@@ -296,13 +329,13 @@ void Channel::Password(ObjectGuid p, const char *pass)
     if (!IsOn(p))
     {
         WorldPacket data;
-        MakeNotMember(&data);
+        MakeNotMember(&data, chanName);
         SendToOne(&data, p);
     }
     else if (!m_players[p].IsModerator() && sec < SEC_GAMEMASTER)
     {
         WorldPacket data;
-        MakeNotModerator(&data);
+        MakeNotModerator(&data, chanName);
         SendToOne(&data, p);
     }
     else
@@ -310,12 +343,12 @@ void Channel::Password(ObjectGuid p, const char *pass)
         m_password = pass;
 
         WorldPacket data;
-        MakePasswordChanged(&data, p);
+        MakePasswordChanged(&data, p, chanName);
         SendToAll(&data);
     }
 }
 
-void Channel::SetMode(ObjectGuid p, const char *p2n, bool mod, bool set)
+void Channel::SetMode(ObjectGuid p, const char *p2n, bool mod, bool set, const char *chanName)
 {
     PlayerPointer plr = GetPlayer(p);
     if (!plr.get())
@@ -326,13 +359,13 @@ void Channel::SetMode(ObjectGuid p, const char *p2n, bool mod, bool set)
     if (!IsOn(p))
     {
         WorldPacket data;
-        MakeNotMember(&data);
+        MakeNotMember(&data, chanName);
         SendToOne(&data, p);
     }
     else if (!m_players[p].IsModerator() && sec < SEC_GAMEMASTER)
     {
         WorldPacket data;
-        MakeNotModerator(&data);
+        MakeNotModerator(&data, chanName);
         SendToOne(&data, p);
     }
     else
@@ -341,7 +374,7 @@ void Channel::SetMode(ObjectGuid p, const char *p2n, bool mod, bool set)
         if (!newp.get())
         {
             WorldPacket data;
-            MakePlayerNotFound(&data, p2n);
+            MakePlayerNotFound(&data, p2n, chanName);
             SendToOne(&data, p);
             return;
         }
@@ -353,7 +386,7 @@ void Channel::SetMode(ObjectGuid p, const char *p2n, bool mod, bool set)
         if (!IsOn(newp->GetObjectGuid()))
         {
             WorldPacket data;
-            MakePlayerNotFound(&data, p2n);
+            MakePlayerNotFound(&data, p2n, chanName);
             SendToOne(&data, p);
             return;
         }
@@ -364,7 +397,7 @@ void Channel::SetMode(ObjectGuid p, const char *p2n, bool mod, bool set)
                 plr->GetTeam() != newp->GetTeam() && !sWorld.getConfig(CONFIG_BOOL_ALLOW_TWO_SIDE_INTERACTION_CHANNEL))
         {
             WorldPacket data;
-            MakePlayerNotFound(&data, p2n);
+            MakePlayerNotFound(&data, p2n, chanName);
             SendToOne(&data, p);
             return;
         }
@@ -372,7 +405,7 @@ void Channel::SetMode(ObjectGuid p, const char *p2n, bool mod, bool set)
         if (m_ownerGuid == newp->GetObjectGuid() && m_ownerGuid != p)
         {
             WorldPacket data;
-            MakeNotOwner(&data);
+            MakeNotOwner(&data, chanName);
             SendToOne(&data, p);
             return;
         }
@@ -382,14 +415,14 @@ void Channel::SetMode(ObjectGuid p, const char *p2n, bool mod, bool set)
             if (HasFlag(CHANNEL_FLAG_GENERAL) && newp->GetSession()->GetSecurity() < SEC_GAMEMASTER)
                 return;
 
-            SetModerator(newp->GetObjectGuid(), set);
+            SetModerator(newp->GetObjectGuid(), set, chanName);
         }
         else
-            SetMute(newp->GetObjectGuid(), set);
+            SetMute(newp->GetObjectGuid(), set, chanName);
     }
 }
 
-void Channel::SetOwner(ObjectGuid p, const char *newname)
+void Channel::SetOwner(ObjectGuid p, const char *newname, const char * chanName)
 {
     PlayerPointer plr = GetPlayer(p);
     if (!plr.get())
@@ -400,7 +433,7 @@ void Channel::SetOwner(ObjectGuid p, const char *newname)
     if (!IsOn(p))
     {
         WorldPacket data;
-        MakeNotMember(&data);
+        MakeNotMember(&data, chanName);
         SendToOne(&data, p);
         return;
     }
@@ -408,7 +441,7 @@ void Channel::SetOwner(ObjectGuid p, const char *newname)
     if (sec < SEC_GAMEMASTER && p != m_ownerGuid)
     {
         WorldPacket data;
-        MakeNotOwner(&data);
+        MakeNotOwner(&data, chanName);
         SendToOne(&data, p);
         return;
     }
@@ -417,7 +450,7 @@ void Channel::SetOwner(ObjectGuid p, const char *newname)
     if (!newp || !IsOn(newp->GetObjectGuid()))
     {
         WorldPacket data;
-        MakePlayerNotFound(&data, newname);
+        MakePlayerNotFound(&data, newname, chanName);
         SendToOne(&data, p);
         return;
     }
@@ -425,7 +458,7 @@ void Channel::SetOwner(ObjectGuid p, const char *newname)
     if (newp->GetTeam() != plr->GetTeam() && !sWorld.getConfig(CONFIG_BOOL_ALLOW_TWO_SIDE_INTERACTION_CHANNEL))
     {
         WorldPacket data;
-        MakePlayerNotFound(&data, newname);
+        MakePlayerNotFound(&data, newname, chanName);
         SendToOne(&data, p);
         return;
     }
@@ -434,26 +467,26 @@ void Channel::SetOwner(ObjectGuid p, const char *newname)
         return;
 
     m_players[newp->GetObjectGuid()].SetModerator(true);
-    SetOwner(newp->GetObjectGuid());
+    SetOwner(newp->GetObjectGuid(), chanName);
 }
 
-void Channel::SendWhoOwner(ObjectGuid p)
+void Channel::SendWhoOwner(ObjectGuid p, const char * chanName)
 {
     if (!IsOn(p))
     {
         WorldPacket data;
-        MakeNotMember(&data);
+        MakeNotMember(&data, chanName);
         SendToOne(&data, p);
     }
     else
     {
         WorldPacket data;
-        MakeChannelOwner(&data);
+        MakeChannelOwner(&data, chanName);
         SendToOne(&data, p);
     }
 }
 
-void Channel::List(PlayerPointer player)
+void Channel::List(PlayerPointer player, const char * chanName)
 {
     ObjectGuid p = player->GetObjectGuid();
 
@@ -463,7 +496,7 @@ void Channel::List(PlayerPointer player)
     if (!IsOn(p))
     {
         WorldPacket data;
-        MakeNotMember(&data);
+        MakeNotMember(&data, chanName);
         SendToOne(&data, p);
     }
     else
@@ -516,7 +549,7 @@ void Channel::List(PlayerPointer player)
     }
 }
 
-void Channel::Announce(ObjectGuid p)
+void Channel::Announce(ObjectGuid p, const char* chanName)
 {
     uint32 sec = 0;
     PlayerPointer plr = GetPlayer(p);
@@ -526,13 +559,13 @@ void Channel::Announce(ObjectGuid p)
     if (!IsOn(p))
     {
         WorldPacket data;
-        MakeNotMember(&data);
+        MakeNotMember(&data, chanName);
         SendToOne(&data, p);
     }
     else if (!m_players[p].IsModerator() && sec < SEC_GAMEMASTER)
     {
         WorldPacket data;
-        MakeNotModerator(&data);
+        MakeNotModerator(&data, chanName);
         SendToOne(&data, p);
     }
     else
@@ -541,14 +574,14 @@ void Channel::Announce(ObjectGuid p)
 
         WorldPacket data;
         if (m_announce)
-            MakeAnnouncementsOn(&data, p);
+            MakeAnnouncementsOn(&data, p, chanName);
         else
-            MakeAnnouncementsOff(&data, p);
+            MakeAnnouncementsOff(&data, p, chanName);
         SendToAll(&data);
     }
 }
 
-void Channel::Moderate(ObjectGuid p)
+void Channel::Moderate(ObjectGuid p, const char* chanName)
 {
     uint32 sec = 0;
     PlayerPointer plr = GetPlayer(p);
@@ -558,13 +591,13 @@ void Channel::Moderate(ObjectGuid p)
     if (!IsOn(p))
     {
         WorldPacket data;
-        MakeNotMember(&data);
+        MakeNotMember(&data, chanName);
         SendToOne(&data, p);
     }
     else if (!m_players[p].IsModerator() && sec < SEC_GAMEMASTER)
     {
         WorldPacket data;
-        MakeNotModerator(&data);
+        MakeNotModerator(&data, chanName);
         SendToOne(&data, p);
     }
     else
@@ -573,14 +606,14 @@ void Channel::Moderate(ObjectGuid p)
 
         WorldPacket data;
         if (m_moderate)
-            MakeModerationOn(&data, p);
+            MakeModerationOn(&data, p, chanName);
         else
-            MakeModerationOff(&data, p);
+            MakeModerationOff(&data, p, chanName);
         SendToAll(&data);
     }
 }
 
-void Channel::Say(ObjectGuid p, const char *what, uint32 lang, bool skipCheck)
+void Channel::Say(ObjectGuid p, const char *what, const char* chanName, uint32 lang, bool skipCheck)
 {
     if (!what)
         return;
@@ -589,36 +622,42 @@ void Channel::Say(ObjectGuid p, const char *what, uint32 lang, bool skipCheck)
 
     uint32 sec = 0;
     PlayerPointer plr = GetPlayer(p);
+    int32 playerRank = 0;
+
     if (plr)
+    {
         sec = plr->GetSession()->GetSecurity();
+        if (GetChannelId() == CHANNEL_ID_LOCAL_DEFENSE || GetChannelId() == CHANNEL_ID_WORLD_DEFENSE)
+            playerRank = plr->GetHonorRankInfo().rank;
+    }
 
     if (!skipCheck && !IsOn(p))
     {
         WorldPacket data;
-        MakeNotMember(&data);
+        MakeNotMember(&data, chanName);
         SendToOne(&data, p);
     }
     else if (!skipCheck && m_players[p].IsMuted())
     {
         WorldPacket data;
-        MakeMuted(&data);
+        MakeMuted(&data, chanName);
         SendToOne(&data, p);
     }
     else if (!skipCheck && m_moderate && !m_players[p].IsModerator() && sec < SEC_GAMEMASTER)
     {
         WorldPacket data;
-        MakeNotModerator(&data);
+        MakeNotModerator(&data, chanName);
         SendToOne(&data, p);
     }
-    else
+    else if (GetChannelId() == 0)
     {
         uint32 messageLength = strlen(what) + 1;
-
-        WorldPacket data(SMSG_MESSAGECHAT, 1 + 4 + 8 + 4 + m_name.size() + 1 + 8 + 4 + messageLength + 1);
+        std::string localizedChannelName = GetLocalName(plr->GetSession()->GetSessionDbcLocale());
+        WorldPacket data(SMSG_MESSAGECHAT, 1 + 4 + 8 + 4 + localizedChannelName.size() + 1 + 8 + 4 + messageLength + 1);
         data << uint8(CHAT_MSG_CHANNEL);
         data << uint32(lang);
-        data << m_name;
-        data << uint32(0);
+        data << localizedChannelName.c_str();
+        data << uint32(playerRank);
         data << ObjectGuid(p);
         data << uint32(messageLength);
         data << what;
@@ -631,14 +670,38 @@ void Channel::Say(ObjectGuid p, const char *what, uint32 lang, bool skipCheck)
         else
             SendToAll(&data, (!skipCheck && !m_players[p].IsModerator()) ? p : ObjectGuid());
     }
+    else
+    {
+        for (PlayerList::const_iterator i = m_players.begin(); i != m_players.end(); ++i)
+        {
+            if (Player* plrtarget = sObjectMgr.GetPlayer(i->first))
+            {
+                if (!plrtarget->GetSocial()->HasIgnore(p))
+                {
+                    uint32 messageLength = strlen(what) + 1;
+                    std::string localizedChannelName = GetLocalName(plrtarget->GetSession()->GetSessionDbcLocale());
+                    WorldPacket data(SMSG_MESSAGECHAT, 1 + 4 + 8 + 4 + localizedChannelName.size() + 1 + 8 + 4 + messageLength + 1);
+                    data << uint8(CHAT_MSG_CHANNEL);
+                    data << uint32(lang);
+                    data << localizedChannelName.c_str();
+                    data << uint32(playerRank);
+                    data << ObjectGuid(p);
+                    data << uint32(messageLength);
+                    data << what;
+                    data << uint8(plr ? plr->chatTag() : 0);
+                    plrtarget->GetSession()->SendPacket(&data);
+                }
+            }
+        }
+    }
 }
 
-void Channel::Invite(ObjectGuid p, const char *newname)
+void Channel::Invite(ObjectGuid p, const char *newname, const char *chanName)
 {
     if (!IsOn(p))
     {
         WorldPacket data;
-        MakeNotMember(&data);
+        MakeNotMember(&data, chanName);
         SendToOne(&data, p);
         return;
     }
@@ -647,7 +710,7 @@ void Channel::Invite(ObjectGuid p, const char *newname)
     if (!newp)
     {
         WorldPacket data;
-        MakePlayerNotFound(&data, newname);
+        MakePlayerNotFound(&data, newname, chanName);
         SendToOne(&data, p);
         return;
     }
@@ -659,7 +722,7 @@ void Channel::Invite(ObjectGuid p, const char *newname)
     if (newp->GetTeam() != plr->GetTeam() && !sWorld.getConfig(CONFIG_BOOL_ALLOW_TWO_SIDE_INTERACTION_CHANNEL))
     {
         WorldPacket data;
-        MakeInviteWrongFaction(&data);
+        MakeInviteWrongFaction(&data, chanName);
         SendToOne(&data, p);
         return;
     }
@@ -667,7 +730,7 @@ void Channel::Invite(ObjectGuid p, const char *newname)
     if (IsOn(newp->GetObjectGuid()))
     {
         WorldPacket data;
-        MakePlayerAlreadyMember(&data, newp->GetObjectGuid());
+        MakePlayerAlreadyMember(&data, newp->GetObjectGuid(), chanName);
         SendToOne(&data, p);
         return;
     }
@@ -675,15 +738,15 @@ void Channel::Invite(ObjectGuid p, const char *newname)
     WorldPacket data;
     if (!newp->GetSocial()->HasIgnore(p))
     {
-        MakeInvite(&data, p);
+        MakeInvite(&data, p, chanName);
         SendToOne(&data, newp->GetObjectGuid());
         data.clear();
     }
-    MakePlayerInvited(&data, newp->GetName());
+    MakePlayerInvited(&data, newp->GetName(), chanName);
     SendToOne(&data, p);
 }
 
-void Channel::SetOwner(ObjectGuid guid, bool exclaim)
+void Channel::SetOwner(ObjectGuid guid, const char * chanName, bool exclaim)
 {
     PlayerPointer newp = GetPlayer(guid);
     if (!newp)
@@ -708,12 +771,12 @@ void Channel::SetOwner(ObjectGuid guid, bool exclaim)
         m_players[m_ownerGuid].SetOwner(true);
 
         WorldPacket data;
-        MakeModeChange(&data, m_ownerGuid, oldFlag);
+        MakeModeChange(&data, m_ownerGuid, oldFlag, chanName);
         SendToAll(&data);
 
         if (exclaim)
         {
-            MakeOwnerChanged(&data, m_ownerGuid);
+            MakeOwnerChanged(&data, m_ownerGuid, chanName);
             SendToAll(&data);
         }
     }
@@ -736,255 +799,255 @@ void Channel::SendToOne(WorldPacket *data, ObjectGuid who)
         plr->GetSession()->SendPacket(data);
 }
 
-void Channel::Voice(ObjectGuid /*guid1*/, ObjectGuid /*guid2*/)
+void Channel::Voice(ObjectGuid /*guid1*/, ObjectGuid /*guid2*/, const char * /*chanName*/)
 {
 
 }
 
-void Channel::DeVoice(ObjectGuid /*guid1*/, ObjectGuid /*guid2*/)
+void Channel::DeVoice(ObjectGuid /*guid1*/, ObjectGuid /*guid2*/, const char * /*chanName*/)
 {
 
 }
 
 // done
-void Channel::MakeNotifyPacket(WorldPacket *data, uint8 notify_type)
+void Channel::MakeNotifyPacket(WorldPacket *data, uint8 notify_type, std::string chanName)
 {
-    data->Initialize(SMSG_CHANNEL_NOTIFY, 1 + m_name.size() + 1);
+    data->Initialize(SMSG_CHANNEL_NOTIFY, 1 + chanName.size() + 1);
     *data << uint8(notify_type);
-    *data << m_name;
+    *data << chanName;
 }
 
 // done 0x00
-void Channel::MakeJoined(WorldPacket *data, ObjectGuid guid)
+void Channel::MakeJoined(WorldPacket *data, ObjectGuid guid, std::string chanName)
 {
-    MakeNotifyPacket(data, CHAT_JOINED_NOTICE);
+    MakeNotifyPacket(data, CHAT_JOINED_NOTICE, chanName);
     *data << ObjectGuid(guid);
 }
 
 // done 0x01
-void Channel::MakeLeft(WorldPacket *data, ObjectGuid guid)
+void Channel::MakeLeft(WorldPacket *data, ObjectGuid guid, std::string chanName)
 {
-    MakeNotifyPacket(data, CHAT_LEFT_NOTICE);
+    MakeNotifyPacket(data, CHAT_LEFT_NOTICE, chanName);
     *data << ObjectGuid(guid);
 }
 
 // done 0x02
-void Channel::MakeYouJoined(WorldPacket *data)
+void Channel::MakeYouJoined(WorldPacket *data, std::string chanName)
 {
-    MakeNotifyPacket(data, CHAT_YOU_JOINED_NOTICE);
+    MakeNotifyPacket(data, CHAT_YOU_JOINED_NOTICE, chanName);
     *data << uint8(GetFlags());
     *data << uint32(GetChannelId());
     *data << uint32(0);
 }
 
 // done 0x03
-void Channel::MakeYouLeft(WorldPacket *data)
+void Channel::MakeYouLeft(WorldPacket *data, std::string chanName)
 {
-    MakeNotifyPacket(data, CHAT_YOU_LEFT_NOTICE);
+    MakeNotifyPacket(data, CHAT_YOU_LEFT_NOTICE, chanName);
     *data << uint32(GetChannelId());
     *data << uint8(0);                                      // can be 0x00 and 0x01
 }
 
 // done 0x04
-void Channel::MakeWrongPassword(WorldPacket *data)
+void Channel::MakeWrongPassword(WorldPacket *data, std::string chanName)
 {
-    MakeNotifyPacket(data, CHAT_WRONG_PASSWORD_NOTICE);
+    MakeNotifyPacket(data, CHAT_WRONG_PASSWORD_NOTICE, chanName);
 }
 
 // done 0x05
-void Channel::MakeNotMember(WorldPacket *data)
+void Channel::MakeNotMember(WorldPacket *data, std::string chanName)
 {
-    MakeNotifyPacket(data, CHAT_NOT_MEMBER_NOTICE);
+    MakeNotifyPacket(data, CHAT_NOT_MEMBER_NOTICE, chanName);
 }
 
 // done 0x06
-void Channel::MakeNotModerator(WorldPacket *data)
+void Channel::MakeNotModerator(WorldPacket *data, std::string chanName)
 {
-    MakeNotifyPacket(data, CHAT_NOT_MODERATOR_NOTICE);
+    MakeNotifyPacket(data, CHAT_NOT_MODERATOR_NOTICE, chanName);
 }
 
 // done 0x07
-void Channel::MakePasswordChanged(WorldPacket *data, ObjectGuid guid)
+void Channel::MakePasswordChanged(WorldPacket *data, ObjectGuid guid, std::string chanName)
 {
-    MakeNotifyPacket(data, CHAT_PASSWORD_CHANGED_NOTICE);
+    MakeNotifyPacket(data, CHAT_PASSWORD_CHANGED_NOTICE, chanName);
     *data << ObjectGuid(guid);
 }
 
 // done 0x08
-void Channel::MakeOwnerChanged(WorldPacket *data, ObjectGuid guid)
+void Channel::MakeOwnerChanged(WorldPacket *data, ObjectGuid guid, std::string chanName)
 {
-    MakeNotifyPacket(data, CHAT_OWNER_CHANGED_NOTICE);
+    MakeNotifyPacket(data, CHAT_OWNER_CHANGED_NOTICE, chanName);
     *data << ObjectGuid(guid);
 }
 
 // done 0x09
-void Channel::MakePlayerNotFound(WorldPacket *data, const std::string& name)
+void Channel::MakePlayerNotFound(WorldPacket *data, const std::string& name, std::string chanName)
 {
-    MakeNotifyPacket(data, CHAT_PLAYER_NOT_FOUND_NOTICE);
+    MakeNotifyPacket(data, CHAT_PLAYER_NOT_FOUND_NOTICE, chanName);
     *data << name;
 }
 
 // done 0x0A
-void Channel::MakeNotOwner(WorldPacket *data)
+void Channel::MakeNotOwner(WorldPacket *data, std::string chanName)
 {
-    MakeNotifyPacket(data, CHAT_NOT_OWNER_NOTICE);
+    MakeNotifyPacket(data, CHAT_NOT_OWNER_NOTICE, chanName);
 }
 
 // done 0x0B
-void Channel::MakeChannelOwner(WorldPacket *data)
+void Channel::MakeChannelOwner(WorldPacket *data, std::string chanName)
 {
     std::string name = "";
 
     if (!sObjectMgr.GetPlayerNameByGUID(m_ownerGuid, name) || name.empty())
         name = "PLAYER_NOT_FOUND";
 
-    MakeNotifyPacket(data, CHAT_CHANNEL_OWNER_NOTICE);
+    MakeNotifyPacket(data, CHAT_CHANNEL_OWNER_NOTICE, chanName);
     *data << ((IsConstant() || !m_ownerGuid) ? "Nobody" : name);
 }
 
 // done 0x0C
-void Channel::MakeModeChange(WorldPacket *data, ObjectGuid guid, uint8 oldflags)
+void Channel::MakeModeChange(WorldPacket *data, ObjectGuid guid, uint8 oldflags, std::string chanName)
 {
-    MakeNotifyPacket(data, CHAT_MODE_CHANGE_NOTICE);
+    MakeNotifyPacket(data, CHAT_MODE_CHANGE_NOTICE, chanName);
     *data << ObjectGuid(guid);
     *data << uint8(oldflags);
     *data << uint8(GetPlayerFlags(guid));
 }
 
 // done 0x0D
-void Channel::MakeAnnouncementsOn(WorldPacket *data, ObjectGuid guid)
+void Channel::MakeAnnouncementsOn(WorldPacket *data, ObjectGuid guid, std::string chanName)
 {
-    MakeNotifyPacket(data, CHAT_ANNOUNCEMENTS_ON_NOTICE);
+    MakeNotifyPacket(data, CHAT_ANNOUNCEMENTS_ON_NOTICE, chanName);
     *data << ObjectGuid(guid);
 }
 
 // done 0x0E
-void Channel::MakeAnnouncementsOff(WorldPacket *data, ObjectGuid guid)
+void Channel::MakeAnnouncementsOff(WorldPacket *data, ObjectGuid guid, std::string chanName)
 {
-    MakeNotifyPacket(data, CHAT_ANNOUNCEMENTS_OFF_NOTICE);
+    MakeNotifyPacket(data, CHAT_ANNOUNCEMENTS_OFF_NOTICE, chanName);
     *data << ObjectGuid(guid);
 }
 
 // done 0x0F
-void Channel::MakeModerationOn(WorldPacket *data, ObjectGuid guid)
+void Channel::MakeModerationOn(WorldPacket *data, ObjectGuid guid, std::string chanName)
 {
-    MakeNotifyPacket(data, CHAT_MODERATION_ON_NOTICE);
+    MakeNotifyPacket(data, CHAT_MODERATION_ON_NOTICE, chanName);
     *data << ObjectGuid(guid);
 }
 
 // done 0x10
-void Channel::MakeModerationOff(WorldPacket *data, ObjectGuid guid)
+void Channel::MakeModerationOff(WorldPacket *data, ObjectGuid guid, std::string chanName)
 {
-    MakeNotifyPacket(data, CHAT_MODERATION_OFF_NOTICE);
+    MakeNotifyPacket(data, CHAT_MODERATION_OFF_NOTICE, chanName);
     *data << ObjectGuid(guid);
 }
 
 // done 0x11
-void Channel::MakeMuted(WorldPacket *data)
+void Channel::MakeMuted(WorldPacket *data, std::string chanName)
 {
-    MakeNotifyPacket(data, CHAT_MUTED_NOTICE);
+    MakeNotifyPacket(data, CHAT_MUTED_NOTICE, chanName);
 }
 
 // done 0x12
-void Channel::MakePlayerKicked(WorldPacket *data, ObjectGuid bad, ObjectGuid good)
+void Channel::MakePlayerKicked(WorldPacket *data, ObjectGuid bad, ObjectGuid good, std::string chanName)
 {
-    MakeNotifyPacket(data, CHAT_PLAYER_KICKED_NOTICE);
+    MakeNotifyPacket(data, CHAT_PLAYER_KICKED_NOTICE, chanName);
     *data << ObjectGuid(bad);
     *data << ObjectGuid(good);
 }
 
 // done 0x13
-void Channel::MakeBanned(WorldPacket *data)
+void Channel::MakeBanned(WorldPacket *data, std::string chanName)
 {
-    MakeNotifyPacket(data, CHAT_BANNED_NOTICE);
+    MakeNotifyPacket(data, CHAT_BANNED_NOTICE, chanName);
 }
 
 // done 0x14
-void Channel::MakePlayerBanned(WorldPacket *data, ObjectGuid bad, ObjectGuid good)
+void Channel::MakePlayerBanned(WorldPacket *data, ObjectGuid bad, ObjectGuid good, std::string chanName)
 {
-    MakeNotifyPacket(data, CHAT_PLAYER_BANNED_NOTICE);
+    MakeNotifyPacket(data, CHAT_PLAYER_BANNED_NOTICE, chanName);
     *data << ObjectGuid(bad);
     *data << ObjectGuid(good);
 }
 
 // done 0x15
-void Channel::MakePlayerUnbanned(WorldPacket *data, ObjectGuid bad, ObjectGuid good)
+void Channel::MakePlayerUnbanned(WorldPacket *data, ObjectGuid bad, ObjectGuid good, std::string chanName)
 {
-    MakeNotifyPacket(data, CHAT_PLAYER_UNBANNED_NOTICE);
+    MakeNotifyPacket(data, CHAT_PLAYER_UNBANNED_NOTICE, chanName);
     *data << ObjectGuid(bad);
     *data << ObjectGuid(good);
 }
 
 // done 0x16
-void Channel::MakePlayerNotBanned(WorldPacket *data, ObjectGuid guid)
+void Channel::MakePlayerNotBanned(WorldPacket *data, ObjectGuid guid, std::string chanName)
 {
-    MakeNotifyPacket(data, CHAT_PLAYER_NOT_BANNED_NOTICE);
+    MakeNotifyPacket(data, CHAT_PLAYER_NOT_BANNED_NOTICE, chanName);
     *data << ObjectGuid(guid);                              // should be string!!
 }
 
 // done 0x17
-void Channel::MakePlayerAlreadyMember(WorldPacket *data, ObjectGuid guid)
+void Channel::MakePlayerAlreadyMember(WorldPacket *data, ObjectGuid guid, std::string chanName)
 {
-    MakeNotifyPacket(data, CHAT_PLAYER_ALREADY_MEMBER_NOTICE);
+    MakeNotifyPacket(data, CHAT_PLAYER_ALREADY_MEMBER_NOTICE, chanName);
     *data << ObjectGuid(guid);
 }
 
 // done 0x18
-void Channel::MakeInvite(WorldPacket *data, ObjectGuid guid)
+void Channel::MakeInvite(WorldPacket *data, ObjectGuid guid, std::string chanName)
 {
-    MakeNotifyPacket(data, CHAT_INVITE_NOTICE);
+    MakeNotifyPacket(data, CHAT_INVITE_NOTICE, chanName);
     *data << ObjectGuid(guid);
 }
 
 // done 0x19
-void Channel::MakeInviteWrongFaction(WorldPacket *data)
+void Channel::MakeInviteWrongFaction(WorldPacket *data, std::string chanName)
 {
-    MakeNotifyPacket(data, CHAT_INVITE_WRONG_FACTION_NOTICE);
+    MakeNotifyPacket(data, CHAT_INVITE_WRONG_FACTION_NOTICE, chanName);
 }
 
 // done 0x1A
-void Channel::MakeWrongFaction(WorldPacket *data)
+void Channel::MakeWrongFaction(WorldPacket *data, std::string chanName)
 {
-    MakeNotifyPacket(data, CHAT_WRONG_FACTION_NOTICE);
+    MakeNotifyPacket(data, CHAT_WRONG_FACTION_NOTICE, chanName);
 }
 
 // done 0x1B
-void Channel::MakeInvalidName(WorldPacket *data)
+void Channel::MakeInvalidName(WorldPacket *data, std::string chanName)
 {
-    MakeNotifyPacket(data, CHAT_INVALID_NAME_NOTICE);
+    MakeNotifyPacket(data, CHAT_INVALID_NAME_NOTICE, chanName);
 }
 
 // done 0x1C
-void Channel::MakeNotModerated(WorldPacket *data)
+void Channel::MakeNotModerated(WorldPacket *data, std::string chanName)
 {
-    MakeNotifyPacket(data, CHAT_NOT_MODERATED_NOTICE);
+    MakeNotifyPacket(data, CHAT_NOT_MODERATED_NOTICE, chanName);
 }
 
 // done 0x1D
-void Channel::MakePlayerInvited(WorldPacket *data, const std::string& name)
+void Channel::MakePlayerInvited(WorldPacket *data, const std::string& name, std::string chanName)
 {
-    MakeNotifyPacket(data, CHAT_PLAYER_INVITED_NOTICE);
+    MakeNotifyPacket(data, CHAT_PLAYER_INVITED_NOTICE, chanName);
     *data << name;
 }
 
 // done 0x1E
-void Channel::MakePlayerInviteBanned(WorldPacket *data, ObjectGuid guid)
+void Channel::MakePlayerInviteBanned(WorldPacket *data, ObjectGuid guid, std::string chanName)
 {
-    MakeNotifyPacket(data, CHAT_PLAYER_INVITE_BANNED_NOTICE);
+    MakeNotifyPacket(data, CHAT_PLAYER_INVITE_BANNED_NOTICE, chanName);
     *data << ObjectGuid(guid);                              // should be string!!
 }
 
 // done 0x1F
-void Channel::MakeThrottled(WorldPacket *data)
+void Channel::MakeThrottled(WorldPacket *data, std::string chanName)
 {
-    MakeNotifyPacket(data, CHAT_THROTTLED_NOTICE);
+    MakeNotifyPacket(data, CHAT_THROTTLED_NOTICE, chanName);
 }
 
-void Channel::JoinNotify(ObjectGuid guid)
+void Channel::JoinNotify(ObjectGuid guid, const char* chanName)
 {
 }
 
-void Channel::LeaveNotify(ObjectGuid guid)
+void Channel::LeaveNotify(ObjectGuid guid, const char* chanName)
 {
 }
 

--- a/src/game/Chat/Channel.h
+++ b/src/game/Chat/Channel.h
@@ -70,6 +70,21 @@ enum ChatNotify
     CHAT_THROTTLED_NOTICE             = 0x1F,               //+ "[%s] The number of messages that can be sent to this channel is limited, please wait to send another message.";
 };
 
+/**
+ * These are the channel id's for the special channels that's always there, this is currently only
+ * used to find the Local Defense channel as it's muted by default except for if you've got PvP rank 9
+ * \see Channel::m_channelId
+ */
+enum ChannelIds
+{
+    CHANNEL_ID_GENERAL           = 1,
+    CHANNEL_ID_TRADE             = 2,
+    CHANNEL_ID_LOCAL_DEFENSE     = 22,
+    CHANNEL_ID_WORLD_DEFENSE     = 23,
+    CHANNEL_ID_LOOKING_FOR_GROUP = 24,
+    CHANNEL_ID_GUILD_RECRUITMENT = 25
+};
+
 class Channel
 {
     public:
@@ -145,7 +160,10 @@ class Channel
         }
     };
 
-        Channel(const std::string& name);
+        Channel(const std::string& name, const std::string& originalName, LocaleConstant locale);
+        ~Channel();
+        void SetLocalName(LocaleConstant locale, std::string localname);
+        std::string GetLocalName(LocaleConstant locale);
         std::string GetName() const { return m_name; }
         uint32 GetChannelId() const { return m_channelId; }
         bool IsConstant() const { return m_channelId != 0; }
@@ -161,67 +179,68 @@ class Channel
         void SetSecurityLevel(uint8 sec) { m_securityLevel = sec; }
         uint8 GetSecurityLevel() const { return m_securityLevel; }
 
-        void Join(ObjectGuid p, const char *pass);
-        void Leave(ObjectGuid p, bool send = true);
-        void KickOrBan(ObjectGuid good, const char *badname, bool ban);
-        void Kick(ObjectGuid good, const char *badname) { KickOrBan(good, badname, false); }
-        void Ban(ObjectGuid good, const char *badname) { KickOrBan(good, badname, true); }
-        void UnBan(ObjectGuid good, const char *badname);
-        void Password(ObjectGuid p, const char *pass);
-        void SetMode(ObjectGuid p, const char *p2n, bool mod, bool set);
-        void SetOwner(ObjectGuid p, bool exclaim = true);
-        void SetOwner(ObjectGuid p, const char *newname);
-        void SendWhoOwner(ObjectGuid p);
-        void SetModerator(ObjectGuid p, const char *newname) { SetMode(p, newname, true, true); }
-        void UnsetModerator(ObjectGuid p, const char *newname) { SetMode(p, newname, true, false); }
-        void SetMute(ObjectGuid p, const char *newname) { SetMode(p, newname, false, true); }
-        void UnsetMute(ObjectGuid p, const char *newname) { SetMode(p, newname, false, false); }
-        void List(PlayerPointer p);
-        void Announce(ObjectGuid p);
-        void Moderate(ObjectGuid p);
-        void Say(ObjectGuid p, const char *what, uint32 lang = LANG_UNIVERSAL, bool skipCheck = false);
-        void Invite(ObjectGuid p, const char *newp);
-        void Voice(ObjectGuid guid1, ObjectGuid guid2);
-        void DeVoice(ObjectGuid guid1, ObjectGuid guid2);
-        void JoinNotify(ObjectGuid guid);                                       // invisible notify
-        void LeaveNotify(ObjectGuid guid);                                      // invisible notify
+        void Join(ObjectGuid p, const char* name, const char *pass);
+        void Leave(ObjectGuid p, const char *chanName, bool send = true);
+        void KickOrBan(ObjectGuid good, const char *badname, bool ban, const char *chanName);
+        void Kick(ObjectGuid good, const char *badname, const char* chanName) { KickOrBan(good, badname, false, chanName); }
+        void Ban(ObjectGuid good, const char *badname, const char* chanName) { KickOrBan(good, badname, true, chanName); }
+        void UnBan(ObjectGuid good, const char *badname, const char* chanName);
+        void Password(ObjectGuid p, const char *pass, const char* chanName);
+        void SetMode(ObjectGuid p, const char *p2n, bool mod, bool set, const char* chanName);
+        void SetOwner(ObjectGuid p, const char* chanName, bool exclaim = true);
+        void SetOwner(ObjectGuid p, const char *newname, const char* chanName);
+        void SendWhoOwner(ObjectGuid p, const char* chanName);
+        void SetModerator(ObjectGuid p, const char *newname, const char* chanName) { SetMode(p, newname, true, true, chanName); }
+        void UnsetModerator(ObjectGuid p, const char *newname, const char* chanName) { SetMode(p, newname, true, false, chanName); }
+        void SetMute(ObjectGuid p, const char *newname, const char* chanName) { SetMode(p, newname, false, true, chanName); }
+        void UnsetMute(ObjectGuid p, const char *newname, const char* chanName) { SetMode(p, newname, false, false, chanName); }
+        void List(PlayerPointer p, const char* chanName);
+        void Announce(ObjectGuid p, const char* chanName);
+        void Moderate(ObjectGuid p, const char* chanName);
+        void Say(ObjectGuid p, const char *what, const char* chanName, uint32 lang = LANG_UNIVERSAL, bool skipCheck = false);
+        void Invite(ObjectGuid p, const char *newp, const char* chanName);
+        void Voice(ObjectGuid guid1, ObjectGuid guid2, const char* chanName);
+        void DeVoice(ObjectGuid guid1, ObjectGuid guid2, const char* chanName);
+		bool IsPlayerOnChannel(ObjectGuid who) { return IsOn(who); }
+        void JoinNotify(ObjectGuid guid, const char* chanName);                                       // invisible notify
+        void LeaveNotify(ObjectGuid guid, const char* chanName);                                      // invisible notify
 
     private:
         // initial packet data (notify type and channel name)
-        void MakeNotifyPacket(WorldPacket *data, uint8 notify_type);
+        void MakeNotifyPacket(WorldPacket *data, uint8 notify_type, std::string ChanName);
         // type specific packet data
-        void MakeJoined(WorldPacket *data, ObjectGuid guid);                    //+ 0x00
-        void MakeLeft(WorldPacket *data, ObjectGuid guid);                      //+ 0x01
-        void MakeYouJoined(WorldPacket *data);                                  //+ 0x02
-        void MakeYouLeft(WorldPacket *data);                                    //+ 0x03
-        void MakeWrongPassword(WorldPacket *data);                              //? 0x04
-        void MakeNotMember(WorldPacket *data);                                  //? 0x05
-        void MakeNotModerator(WorldPacket *data);                               //? 0x06
-        void MakePasswordChanged(WorldPacket *data, ObjectGuid guid);           //+ 0x07
-        void MakeOwnerChanged(WorldPacket *data, ObjectGuid guid);              //? 0x08
-        void MakePlayerNotFound(WorldPacket *data, const std::string& name);    //+ 0x09
-        void MakeNotOwner(WorldPacket *data);                                   //? 0x0A
-        void MakeChannelOwner(WorldPacket *data);                               //? 0x0B
-        void MakeModeChange(WorldPacket *data, ObjectGuid guid, uint8 oldflags);//+ 0x0C
-        void MakeAnnouncementsOn(WorldPacket *data, ObjectGuid guid);           //+ 0x0D
-        void MakeAnnouncementsOff(WorldPacket *data, ObjectGuid guid);          //+ 0x0E
-        void MakeModerationOn(WorldPacket *data, ObjectGuid guid);              //+ 0x0F
-        void MakeModerationOff(WorldPacket *data, ObjectGuid guid);             //+ 0x10
-        void MakeMuted(WorldPacket *data);                                      //? 0x11
-        void MakePlayerKicked(WorldPacket *data, ObjectGuid bad, ObjectGuid good);//? 0x12
-        void MakeBanned(WorldPacket *data);                                     //? 0x13
-        void MakePlayerBanned(WorldPacket *data, ObjectGuid bad, ObjectGuid good);//? 0x14
-        void MakePlayerUnbanned(WorldPacket *data, ObjectGuid bad, ObjectGuid good);//? 0x15
-        void MakePlayerNotBanned(WorldPacket *data, ObjectGuid guid);           //? 0x16
-        void MakePlayerAlreadyMember(WorldPacket *data, ObjectGuid guid);       //+ 0x17
-        void MakeInvite(WorldPacket *data, ObjectGuid guid);                    //? 0x18
-        void MakeInviteWrongFaction(WorldPacket *data);                         //? 0x19
-        void MakeWrongFaction(WorldPacket *data);                               //? 0x1A
-        void MakeInvalidName(WorldPacket *data);                                //? 0x1B
-        void MakeNotModerated(WorldPacket *data);                               //? 0x1C
-        void MakePlayerInvited(WorldPacket *data, const std::string& name);     //+ 0x1D
-        void MakePlayerInviteBanned(WorldPacket *data, ObjectGuid guid);        //? 0x1E
-        void MakeThrottled(WorldPacket *data);                                  //? 0x1F
+        void MakeJoined(WorldPacket *data, ObjectGuid guid, std::string ChanName);                    //+ 0x00
+        void MakeLeft(WorldPacket *data, ObjectGuid guid, std::string ChanName);                      //+ 0x01
+        void MakeYouJoined(WorldPacket *data, std::string ChanName);                                  //+ 0x02
+        void MakeYouLeft(WorldPacket *data, std::string ChanName);                                    //+ 0x03
+        void MakeWrongPassword(WorldPacket *data, std::string ChanName);                              //? 0x04
+        void MakeNotMember(WorldPacket *data, std::string ChanName);                                  //? 0x05
+        void MakeNotModerator(WorldPacket *data, std::string ChanName);                               //? 0x06
+        void MakePasswordChanged(WorldPacket *data, ObjectGuid guid, std::string ChanName);           //+ 0x07
+        void MakeOwnerChanged(WorldPacket *data, ObjectGuid guid, std::string ChanName);              //? 0x08
+        void MakePlayerNotFound(WorldPacket *data, const std::string& name, std::string ChanName);    //+ 0x09
+        void MakeNotOwner(WorldPacket *data, std::string ChanName);                                   //? 0x0A
+        void MakeChannelOwner(WorldPacket *data, std::string ChanName);                               //? 0x0B
+        void MakeModeChange(WorldPacket *data, ObjectGuid guid, uint8 oldflags, std::string ChanName);//+ 0x0C
+        void MakeAnnouncementsOn(WorldPacket *data, ObjectGuid guid, std::string ChanName);           //+ 0x0D
+        void MakeAnnouncementsOff(WorldPacket *data, ObjectGuid guid, std::string ChanName);          //+ 0x0E
+        void MakeModerationOn(WorldPacket *data, ObjectGuid guid, std::string ChanName);              //+ 0x0F
+        void MakeModerationOff(WorldPacket *data, ObjectGuid guid, std::string ChanName);             //+ 0x10
+        void MakeMuted(WorldPacket *data, std::string ChanName);                                      //? 0x11
+        void MakePlayerKicked(WorldPacket *data, ObjectGuid bad, ObjectGuid good, std::string ChanName);//? 0x12
+        void MakeBanned(WorldPacket *data, std::string ChanName);                                     //? 0x13
+        void MakePlayerBanned(WorldPacket *data, ObjectGuid bad, ObjectGuid good, std::string ChanName);//? 0x14
+        void MakePlayerUnbanned(WorldPacket *data, ObjectGuid bad, ObjectGuid good, std::string ChanName);//? 0x15
+        void MakePlayerNotBanned(WorldPacket *data, ObjectGuid guid, std::string ChanName);           //? 0x16
+        void MakePlayerAlreadyMember(WorldPacket *data, ObjectGuid guid, std::string ChanName);       //+ 0x17
+        void MakeInvite(WorldPacket *data, ObjectGuid guid, std::string ChanName);                    //? 0x18
+        void MakeInviteWrongFaction(WorldPacket *data, std::string ChanName);                         //? 0x19
+        void MakeWrongFaction(WorldPacket *data, std::string ChanName);                               //? 0x1A
+        void MakeInvalidName(WorldPacket *data, std::string ChanName);                                //? 0x1B
+        void MakeNotModerated(WorldPacket *data, std::string ChanName);                               //? 0x1C
+        void MakePlayerInvited(WorldPacket *data, const std::string& name, std::string ChanName);     //+ 0x1D
+        void MakePlayerInviteBanned(WorldPacket *data, ObjectGuid guid, std::string ChanName);        //? 0x1E
+        void MakeThrottled(WorldPacket *data, std::string ChanName);                                  //? 0x1F
 
         void SendToAll(WorldPacket *data, ObjectGuid p = ObjectGuid());
         void SendToOne(WorldPacket *data, ObjectGuid who);
@@ -238,7 +257,7 @@ class Channel
             return p_itr->second.flags;
         }
 
-        void SetModerator(ObjectGuid p, bool set)
+        void SetModerator(ObjectGuid p, bool set, const char* chanName)
         {
             if (m_players[p].IsModerator() != set)
             {
@@ -246,12 +265,12 @@ class Channel
                 m_players[p].SetModerator(set);
 
                 WorldPacket data;
-                MakeModeChange(&data, p, oldFlag);
+                MakeModeChange(&data, p, oldFlag, chanName);
                 SendToAll(&data);
             }
         }
 
-        void SetMute(ObjectGuid p, bool set)
+        void SetMute(ObjectGuid p, bool set, const char* chanName)
         {
             if (m_players[p].IsMuted() != set)
             {
@@ -259,7 +278,7 @@ class Channel
                 m_players[p].SetMuted(set);
 
                 WorldPacket data;
-                MakeModeChange(&data, p, oldFlag);
+                MakeModeChange(&data, p, oldFlag, chanName);
                 SendToAll(&data);
             }
         }
@@ -277,6 +296,8 @@ class Channel
         uint8       m_securityLevel;
         uint32      m_channelId;
         ObjectGuid  m_ownerGuid;
+
+        std::string *m_localized_names;
 
         typedef     std::map<ObjectGuid, PlayerInfo> PlayerList;
         PlayerList  m_players;

--- a/src/game/Chat/ChannelMgr.cpp
+++ b/src/game/Chat/ChannelMgr.cpp
@@ -38,7 +38,7 @@ ChannelMgr* channelMgr(Team team)
     if (team == HORDE)
         return &MaNGOS::Singleton<HordeChannelMgr>::Instance();
 
-    return NULL;
+    return nullptr;
 }
 
 ChannelMgr::~ChannelMgr()
@@ -49,29 +49,33 @@ ChannelMgr::~ChannelMgr()
     channels.clear();
 }
 
-Channel *ChannelMgr::GetJoinChannel(std::string name, bool allowAreaDependantChans)
+void ChannelMgr::SetJoinChannel(const std::string &name, PlayerPointer p, const std::string &pass, bool allowAreaDependantChans)
 {
     std::wstring wname;
-    Utf8toWStr(name, wname);
+    uint32 zoneid = GetAreaIdByLocalizedName(name);
+    std::string transName = TranslateChannel(name, zoneid);
+    Utf8toWStr(transName, wname);
     wstrToLower(wname);
 
     if (channels.find(wname) == channels.end())
     {
-        ChatChannelsEntry const* ch = GetChannelEntryFor(name);
+        ChatChannelsEntry const* ch = GetChannelEntryFor(transName);
         if (!allowAreaDependantChans && ch && ch->flags & Channel::CHANNEL_DBC_FLAG_ZONE_DEP)
-            return NULL;
-        Channel *nchan = new Channel(name);
+            return;
+        LocaleConstant loc = (p == nullptr ? LOCALE_enUS : p->GetSession()->GetSessionDbcLocale());
+        Channel *nchan = new Channel(transName, name, loc);
         channels[wname] = nchan;
-        return nchan;
     }
-
-    return channels[wname];
+    if (p && !channels[wname]->IsPlayerOnChannel(p->GetObjectGuid()))
+        channels[wname]->Join(p->GetObjectGuid(), name.c_str(), pass.c_str());
 }
 
 Channel *ChannelMgr::GetChannel(std::string name, PlayerPointer p, bool pkt)
 {
     std::wstring wname;
-    Utf8toWStr(name, wname);
+    uint32 zoneid = GetAreaIdByLocalizedName(name);
+    std::string transName = TranslateChannel(name, zoneid);
+    Utf8toWStr(transName, wname);
     wstrToLower(wname);
 
     ChannelMap::const_iterator i = channels.find(wname);
@@ -85,16 +89,20 @@ Channel *ChannelMgr::GetChannel(std::string name, PlayerPointer p, bool pkt)
             p->GetSession()->SendPacket(&data);
         }
 
-        return NULL;
+        return nullptr;
     }
     else
         return i->second;
 }
 
-void ChannelMgr::LeftChannel(std::string name)
+void ChannelMgr::LeftChannel(std::string name, PlayerPointer p)
 {
     std::wstring wname;
-    Utf8toWStr(name, wname);
+    uint32 zoneid = GetAreaIdByLocalizedName(name);
+    if (zoneid == 0 && p)
+        zoneid = p->GetCachedZoneId();
+    std::string transName = TranslateChannel(name, zoneid);
+    Utf8toWStr(transName, wname);
     wstrToLower(wname);
 
     ChannelMap::const_iterator i = channels.find(wname);
@@ -117,18 +125,56 @@ void ChannelMgr::MakeNotOnPacket(WorldPacket *data, std::string name)
     (*data) << (uint8)CHAT_NOT_MEMBER_NOTICE << name;
 }
 
+std::string ChannelMgr::TranslateChannel(std::string channelName, uint32 zoneId)
+{
+    ChatChannelsEntry const* ch = GetChannelEntryFor(channelName);
+
+    if (ch)
+    {
+        std::stringstream sstm;
+        switch (ch->ChannelID)
+        {
+            case CHANNEL_ID_GENERAL:
+                sstm << "MGeneral - " << zoneId;
+                return sstm.str();
+            case CHANNEL_ID_TRADE:
+                return "MTrade";
+            case CHANNEL_ID_LOCAL_DEFENSE:
+                sstm << "MLDefense - " << zoneId;
+                return sstm.str();
+            case CHANNEL_ID_WORLD_DEFENSE:
+                return "MWDefense";
+            case CHANNEL_ID_LOOKING_FOR_GROUP:
+                return "MLFG";
+            case CHANNEL_ID_GUILD_RECRUITMENT:
+                return "MGuild";        }
+    }
+    return channelName;
+}
+
+
 void ChannelMgr::CreateDefaultChannels()
 {
-    GetJoinChannel("Warden")->SetSecurityLevel(SEC_GAMEMASTER);
-    GetJoinChannel("Anticrash")->SetSecurityLevel(SEC_GAMEMASTER);
-    GetJoinChannel("Antiflood")->SetSecurityLevel(SEC_GAMEMASTER);
-    GetJoinChannel("ItemsCheck")->SetSecurityLevel(SEC_GAMEMASTER);
-    GetJoinChannel("GoldDupe")->SetSecurityLevel(SEC_GAMEMASTER);
-    GetJoinChannel("SAC")->SetSecurityLevel(SEC_GAMEMASTER);
-    GetJoinChannel("MailsAC")->SetSecurityLevel(SEC_GAMEMASTER);
-    GetJoinChannel("BotsDetector")->SetSecurityLevel(SEC_GAMEMASTER);
-    GetJoinChannel("ChatSpam")->SetSecurityLevel(SEC_MODERATOR);
-    GetJoinChannel("LowLevelBots")->SetSecurityLevel(SEC_GAMEMASTER);
+    SetJoinChannel("Warden", nullptr, "");
+    GetChannel("Warden", nullptr)->SetSecurityLevel(SEC_GAMEMASTER);
+    SetJoinChannel("Anticrash", nullptr, "");
+    GetChannel("Anticrash", nullptr)->SetSecurityLevel(SEC_GAMEMASTER);
+    SetJoinChannel("Antiflood", nullptr, "");
+    GetChannel("Antiflood", nullptr)->SetSecurityLevel(SEC_GAMEMASTER);
+    SetJoinChannel("ItemsCheck", nullptr, "");
+    GetChannel("ItemsCheck", nullptr)->SetSecurityLevel(SEC_GAMEMASTER);
+    SetJoinChannel("GoldDupe", nullptr, "");
+    GetChannel("GoldDupe", nullptr)->SetSecurityLevel(SEC_GAMEMASTER);
+    SetJoinChannel("SAC", nullptr, "");
+    GetChannel("SAC", nullptr)->SetSecurityLevel(SEC_GAMEMASTER);
+    SetJoinChannel("MailsAC", nullptr, "");
+    GetChannel("MailsAC", nullptr)->SetSecurityLevel(SEC_GAMEMASTER);
+    SetJoinChannel("BotsDetector", nullptr, "");
+    GetChannel("BotsDetector", nullptr)->SetSecurityLevel(SEC_GAMEMASTER);
+    SetJoinChannel("ChatSpam", nullptr, "");
+    GetChannel("ChatSpam", nullptr)->SetSecurityLevel(SEC_MODERATOR);
+    SetJoinChannel("LowLevelBots", nullptr, "");
+    GetChannel("LowLevelBots", nullptr)->SetSecurityLevel(SEC_GAMEMASTER);
 
     for (ChannelMap::iterator it = channels.begin(); it != channels.end(); ++it)
         it->second->SetAnnounce(false);
@@ -136,9 +182,11 @@ void ChannelMgr::CreateDefaultChannels()
 
 void ChannelMgr::AnnounceBothFactionsChannel(std::string channelName, ObjectGuid playerGuid, const char* message)
 {
-    if (Channel* c = channelMgr(HORDE)->GetJoinChannel(channelName))
-        c->Say(playerGuid, message, LANG_UNIVERSAL, true);
+    Player *p = sObjectAccessor.FindPlayer(playerGuid);
+    PlayerPointer plr = PlayerPointer(p ? new PlayerWrapper<Player>(p) : NULL);
+    if (Channel* c = channelMgr(HORDE)->GetChannel(channelName, plr))
+        c->Say(playerGuid, message, channelName.c_str(), LANG_UNIVERSAL, true);
     if (!sWorld.getConfig(CONFIG_BOOL_ALLOW_TWO_SIDE_INTERACTION_CHANNEL))
-        if (Channel* c = channelMgr(ALLIANCE)->GetJoinChannel(channelName))
-            c->Say(playerGuid, message, LANG_UNIVERSAL, true);
+        if (Channel* c = channelMgr(ALLIANCE)->GetChannel(channelName, plr))
+            c->Say(playerGuid, message, channelName.c_str(), LANG_UNIVERSAL, true);
 }

--- a/src/game/Chat/ChannelMgr.h
+++ b/src/game/Chat/ChannelMgr.h
@@ -41,9 +41,10 @@ class ChannelMgr
         }
         ~ChannelMgr();
 
-        Channel *GetJoinChannel(std::string name, bool allowAreaDependantChans = true);
-        Channel *GetChannel(std::string name, PlayerPointer p, bool pkt = true);
-        void LeftChannel(std::string name);
+        void SetJoinChannel(const std::string &name, PlayerPointer p, const std::string &pass, bool allowAreaDependantChans = true);
+        Channel *GetChannel(const std::string name, PlayerPointer p, bool pkt = true);
+        void LeftChannel(std::string name, PlayerPointer p);
+        std::string TranslateChannel(std::string channelName, uint32 zoneId);
         void CreateDefaultChannels();
         static void AnnounceBothFactionsChannel(std::string channelName, ObjectGuid playerGuid, const char* message);
     private:

--- a/src/game/Database/DBCStores.cpp
+++ b/src/game/Database/DBCStores.cpp
@@ -48,6 +48,8 @@ struct WMOAreaTableTripple
 
 typedef std::map<WMOAreaTableTripple, WMOAreaTableEntry const *> WMOAreaInfoByTripple;
 
+DBCStorage <AreaTableEntry> sAreaStore(AreaTableEntryfmt);
+
 static WMOAreaInfoByTripple sWMOAreaInfoByTripple;
 
 DBCStorage <AreaTriggerEntry> sAreaTriggerStore(AreaTriggerEntryfmt);
@@ -212,6 +214,7 @@ void LoadDBCStores(const std::string& dataPath)
     // bitmask for index of fullLocaleNameList
     uint32 availableDbcLocales = 0xFFFFFFFF;
 
+    LoadDBC(availableDbcLocales, bar, bad_dbc_files, sAreaStore,				dbcPath, "AreaTable.dbc");
     LoadDBC(availableDbcLocales, bar, bad_dbc_files, sAreaTriggerStore,         dbcPath, "AreaTrigger.dbc");
     LoadDBC(availableDbcLocales, bar, bad_dbc_files, sAuctionHouseStore,        dbcPath, "AuctionHouse.dbc");
     LoadDBC(availableDbcLocales, bar, bad_dbc_files, sBankBagSlotPricesStore,   dbcPath, "BankBagSlotPrices.dbc");
@@ -540,6 +543,35 @@ uint32 GetTalentSpellCost(uint32 spellId)
     return GetTalentSpellCost(GetTalentSpellPos(spellId));
 }
 
+int32 GetAreaFlagByAreaID(uint32 area_id)
+{
+    AreaTableEntry const* AreaEntry = sAreaStore.LookupEntry(area_id);
+    if (!AreaEntry)
+        return -1;
+
+    return AreaEntry->exploreFlag;
+}
+
+uint32 GetAreaIdByLocalizedName(const std::string& name) // Channel name provided
+{
+    AreaTableEntry const* aEntry = NULL;
+    for (uint32 i = 0; i <= sAreaStore.GetNumRows(); i++)
+    {
+        if (AreaTableEntry const* AreaEntry = sAreaStore.LookupEntry(i))
+        {
+            for (uint32 i = 0; i < MAX_DBC_LOCALE; ++i)
+            {
+                std::string area_name(AreaEntry->area_name[i]);
+                if (area_name.size() > 0 && name.find(" - " + area_name) != std::string::npos)
+                {
+                    return AreaEntry->ID;
+                }
+            }
+        }
+    }
+    return 0;
+}
+
 WMOAreaTableEntry const* GetWMOAreaTableEntryByTripple(int32 rootid, int32 adtid, int32 groupid)
 {
     WMOAreaInfoByTripple::iterator i = sWMOAreaInfoByTripple.find(WMOAreaTableTripple(rootid, adtid, groupid));
@@ -573,11 +605,11 @@ ChatChannelsEntry const* GetChannelEntryFor(const std::string& name)
             for (int loc = 0; loc < MAX_DBC_LOCALE; ++loc)
             {
                 std::string entryName(ch->pattern[loc]);
-                std::size_t removeString = entryName.find("%s");
                 // Not loaded locale
                 if (!entryName.size())
                     continue;
 
+                std::size_t removeString = entryName.find("%s");
                 if (removeString != std::string::npos)
                     entryName.replace(removeString, 2, "");
 
@@ -586,7 +618,7 @@ ChatChannelsEntry const* GetChannelEntryFor(const std::string& name)
             }
         }
     }
-    return NULL;
+    return nullptr;
 }
 /*[-ZERO]
 bool IsTotemCategoryCompatiableWith(uint32 itemTotemCategoryId, uint32 requiredTotemCategoryId)

--- a/src/game/Database/DBCStores.h
+++ b/src/game/Database/DBCStores.h
@@ -39,6 +39,10 @@ uint32 GetTalentSpellCost(uint32 spellId);
 uint32 GetTalentSpellCost(TalentSpellPos const* pos);
 TalentSpellPos const* GetTalentSpellPos(uint32 spellId);
 
+int32 GetAreaFlagByAreaID(uint32 area_id);                  // -1 if not found
+//
+uint32 GetAreaIdByLocalizedName(const std::string& name);
+
 WMOAreaTableEntry const* GetWMOAreaTableEntryByTripple(int32 rootid, int32 adtid, int32 groupid);
 
 uint32 GetVirtualMapForMapAndZone(uint32 mapid, uint32 zoneId);

--- a/src/game/Database/DBCStructure.h
+++ b/src/game/Database/DBCStructure.h
@@ -41,6 +41,28 @@
 #pragma pack(push,1)
 #endif
 
+struct AreaTableEntry
+{
+    uint32  ID;                                             // 0        m_ID
+    uint32  mapid;                                          // 1        m_ContinentID
+    uint32  zone;                                           // 2        m_ParentAreaID
+    uint32  exploreFlag;                                    // 3        m_AreaBit
+    uint32  flags;                                          // 4        m_flags
+															// 5        m_SoundProviderPref
+															// 6        m_SoundProviderPrefUnderwater
+															// 7        m_AmbienceID
+															// 8        m_ZoneMusic
+															// 9        m_IntroSound
+    int32   area_level;                                     // 10       m_ExplorationLevel
+    char*   area_name[8];                                   // 11-18    m_AreaName_lang
+															// 19 string flags
+    uint32  team;                                           // 20       m_factionGroupMask
+															// 21-23    uknown/unused
+    uint32  LiquidTypeOverride;                             // 24       m_liquidTypeID override for water type
+};
+
+#define CAPITAL_ZONE_ID 3459
+
 struct AreaTriggerEntry
 {
     uint32    id;                                           // 0

--- a/src/game/Handlers/ChannelHandler.cpp
+++ b/src/game/Handlers/ChannelHandler.cpp
@@ -40,17 +40,15 @@ void WorldSession::HandleJoinChannelOpcode(WorldPacket& recvPacket)
     PlayerPointer player = GetPlayerPointer();
     if (ChannelMgr* cMgr = channelMgr(player->GetTeam()))
     {
-        if (Channel *chn = cMgr->GetJoinChannel(channelname, IsNode()))
-            chn->Join(player->GetObjectGuid(), pass.c_str());
-        else
-            ForwardPacketToNode();
+        cMgr->SetJoinChannel(channelname, player, pass);
     }
-
     if (player->GetSession()->GetSecurity() > SEC_PLAYER && sWorld.getConfig(CONFIG_BOOL_GM_JOIN_OPPOSITE_FACTION_CHANNELS))
+    {
         if (ChannelMgr* cMgr = channelMgr(_player->GetTeam() == ALLIANCE ? HORDE : ALLIANCE))
-            if (Channel *chn = cMgr->GetJoinChannel(channelname))
+            if (Channel *chn = cMgr->GetChannel(channelname, player))
                 if (!chn->GetSecurityLevel()) // Special both factions channel
-                    chn->Join(player->GetObjectGuid(), pass.c_str());
+                    cMgr->SetJoinChannel(channelname, player, pass);
+    }
 }
 
 void WorldSession::HandleLeaveChannelOpcode(WorldPacket& recvPacket)
@@ -68,18 +66,16 @@ void WorldSession::HandleLeaveChannelOpcode(WorldPacket& recvPacket)
     PlayerPointer player = GetPlayerPointer();
     if (ChannelMgr* cMgr = channelMgr(player->GetTeam()))
     {
-        if (Channel *chn = cMgr->GetChannel(channelname, player, IsNode()))
-            chn->Leave(player->GetObjectGuid(), true);
-        else
-            ForwardPacketToNode();
-        cMgr->LeftChannel(channelname);
+        if (Channel *chn = cMgr->GetChannel(channelname, player))
+            chn->Leave(player->GetObjectGuid(), channelname.c_str(), true);
+        cMgr->LeftChannel(channelname, player);
     }
     if (player->GetSession()->GetSecurity() > SEC_PLAYER && sWorld.getConfig(CONFIG_BOOL_GM_JOIN_OPPOSITE_FACTION_CHANNELS))
         if (ChannelMgr* cMgr = channelMgr(player->GetTeam() == ALLIANCE ? HORDE : ALLIANCE))
         {
             if (Channel *chn = cMgr->GetChannel(channelname, player, IsNode()))
-                chn->Leave(player->GetObjectGuid(), true);
-            cMgr->LeftChannel(channelname);
+                chn->Leave(player->GetObjectGuid(), channelname.c_str(), true);
+            cMgr->LeftChannel(channelname, player);
         }
 }
 
@@ -93,7 +89,7 @@ void WorldSession::HandleChannelListOpcode(WorldPacket& recvPacket)
     PlayerPointer player = GetPlayerPointer();
     if (ChannelMgr* cMgr = channelMgr(player->GetTeam()))
         if (Channel *chn = cMgr->GetChannel(channelname, player, IsNode()))
-            chn->List(player);
+            chn->List(player, channelname.c_str());
         else
             ForwardPacketToNode();
 }
@@ -110,7 +106,7 @@ void WorldSession::HandleChannelPasswordOpcode(WorldPacket& recvPacket)
     PlayerPointer player = GetPlayerPointer();
     if (ChannelMgr* cMgr = channelMgr(player->GetTeam()))
         if (Channel *chn = cMgr->GetChannel(channelname, player, IsNode()))
-            chn->Password(player->GetObjectGuid(), pass.c_str());
+            chn->Password(player->GetObjectGuid(), pass.c_str(), channelname.c_str());
         else
             ForwardPacketToNode();
 }
@@ -131,7 +127,7 @@ void WorldSession::HandleChannelSetOwnerOpcode(WorldPacket& recvPacket)
     PlayerPointer player = GetPlayerPointer();
     if (ChannelMgr* cMgr = channelMgr(player->GetTeam()))
         if (Channel *chn = cMgr->GetChannel(channelname, player, IsNode()))
-            chn->SetOwner(player->GetObjectGuid(), newp.c_str());
+            chn->SetOwner(player->GetObjectGuid(), newp.c_str(), channelname.c_str());
         else
             ForwardPacketToNode();
 }
@@ -146,7 +142,7 @@ void WorldSession::HandleChannelOwnerOpcode(WorldPacket& recvPacket)
     PlayerPointer player = GetPlayerPointer();
     if (ChannelMgr* cMgr = channelMgr(player->GetTeam()))
         if (Channel *chn = cMgr->GetChannel(channelname, player, IsNode()))
-            chn->SendWhoOwner(player->GetObjectGuid());
+            chn->SendWhoOwner(player->GetObjectGuid(), channelname.c_str());
         else
             ForwardPacketToNode();
 }
@@ -166,7 +162,7 @@ void WorldSession::HandleChannelModeratorOpcode(WorldPacket& recvPacket)
     PlayerPointer player = GetPlayerPointer();
     if (ChannelMgr* cMgr = channelMgr(player->GetTeam()))
         if (Channel *chn = cMgr->GetChannel(channelname, player, IsNode()))
-            chn->SetModerator(player->GetObjectGuid(), otp.c_str());
+            chn->SetModerator(player->GetObjectGuid(), otp.c_str(), channelname.c_str());
         else
             ForwardPacketToNode();
 }
@@ -186,7 +182,7 @@ void WorldSession::HandleChannelUnmoderatorOpcode(WorldPacket& recvPacket)
     PlayerPointer player = GetPlayerPointer();
     if (ChannelMgr* cMgr = channelMgr(player->GetTeam()))
         if (Channel *chn = cMgr->GetChannel(channelname, player, IsNode()))
-            chn->UnsetModerator(player->GetObjectGuid(), otp.c_str());
+            chn->UnsetModerator(player->GetObjectGuid(), otp.c_str(), channelname.c_str());
         else
             ForwardPacketToNode();
 }
@@ -206,7 +202,7 @@ void WorldSession::HandleChannelMuteOpcode(WorldPacket& recvPacket)
     PlayerPointer player = GetPlayerPointer();
     if (ChannelMgr* cMgr = channelMgr(player->GetTeam()))
         if (Channel *chn = cMgr->GetChannel(channelname, player, IsNode()))
-            chn->SetMute(player->GetObjectGuid(), otp.c_str());
+            chn->SetMute(player->GetObjectGuid(), otp.c_str(), channelname.c_str());
         else
             ForwardPacketToNode();
 }
@@ -226,7 +222,7 @@ void WorldSession::HandleChannelUnmuteOpcode(WorldPacket& recvPacket)
     PlayerPointer player = GetPlayerPointer();
     if (ChannelMgr* cMgr = channelMgr(player->GetTeam()))
         if (Channel *chn = cMgr->GetChannel(channelname, player, IsNode()))
-            chn->UnsetMute(player->GetObjectGuid(), otp.c_str());
+            chn->UnsetMute(player->GetObjectGuid(), otp.c_str(), channelname.c_str());
         else
             ForwardPacketToNode();
 }
@@ -249,7 +245,7 @@ void WorldSession::HandleChannelInviteOpcode(WorldPacket& recvPacket)
 
     if (ChannelMgr* cMgr = channelMgr(player->GetTeam()))
         if (Channel *chn = cMgr->GetChannel(channelname, player, IsNode()))
-            chn->Invite(player->GetObjectGuid(), otp.c_str());
+            chn->Invite(player->GetObjectGuid(), otp.c_str(), channelname.c_str());
         else
             ForwardPacketToNode();
 }
@@ -268,7 +264,7 @@ void WorldSession::HandleChannelKickOpcode(WorldPacket& recvPacket)
     PlayerPointer player = GetPlayerPointer();
     if (ChannelMgr* cMgr = channelMgr(player->GetTeam()))
         if (Channel *chn = cMgr->GetChannel(channelname, player, IsNode()))
-            chn->Kick(player->GetObjectGuid(), otp.c_str());
+            chn->Kick(player->GetObjectGuid(), otp.c_str(), channelname.c_str());
         else
             ForwardPacketToNode();
 }
@@ -288,7 +284,7 @@ void WorldSession::HandleChannelBanOpcode(WorldPacket& recvPacket)
     PlayerPointer player = GetPlayerPointer();
     if (ChannelMgr* cMgr = channelMgr(player->GetTeam()))
         if (Channel *chn = cMgr->GetChannel(channelname, player, IsNode()))
-            chn->Ban(player->GetObjectGuid(), otp.c_str());
+            chn->Ban(player->GetObjectGuid(), otp.c_str(), channelname.c_str());
         else
             ForwardPacketToNode();
 }
@@ -308,7 +304,7 @@ void WorldSession::HandleChannelUnbanOpcode(WorldPacket& recvPacket)
     PlayerPointer player = GetPlayerPointer();
     if (ChannelMgr* cMgr = channelMgr(player->GetTeam()))
         if (Channel *chn = cMgr->GetChannel(channelname, player, IsNode()))
-            chn->UnBan(player->GetObjectGuid(), otp.c_str());
+            chn->UnBan(player->GetObjectGuid(), otp.c_str(), channelname.c_str());
         else
             ForwardPacketToNode();
 }
@@ -323,7 +319,7 @@ void WorldSession::HandleChannelAnnouncementsOpcode(WorldPacket& recvPacket)
     PlayerPointer player = GetPlayerPointer();
     if (ChannelMgr* cMgr = channelMgr(player->GetTeam()))
         if (Channel *chn = cMgr->GetChannel(channelname, player, IsNode()))
-            chn->Announce(player->GetObjectGuid());
+            chn->Announce(player->GetObjectGuid(), channelname.c_str());
         else
             ForwardPacketToNode();
 }
@@ -338,7 +334,7 @@ void WorldSession::HandleChannelModerateOpcode(WorldPacket& recvPacket)
     PlayerPointer player = GetPlayerPointer();
     if (ChannelMgr* cMgr = channelMgr(player->GetTeam()))
         if (Channel *chn = cMgr->GetChannel(channelname, player, IsNode()))
-            chn->Moderate(player->GetObjectGuid());
+            chn->Moderate(player->GetObjectGuid(), channelname.c_str());
         else
             ForwardPacketToNode();
 }

--- a/src/game/Handlers/ChatHandler.cpp
+++ b/src/game/Handlers/ChatHandler.cpp
@@ -257,7 +257,7 @@ void WorldSession::HandleMessagechatOpcode(WorldPacket & recv_data)
                         }
                     }
 
-                    chn->Say(playerPointer->GetObjectGuid(), msg.c_str(), lang);
+                    chn->Say(playerPointer->GetObjectGuid(), msg.c_str(), channel.c_str(), lang);
 
                     if (lang != LANG_ADDON && chn->HasFlag(Channel::ChannelFlags::CHANNEL_FLAG_GENERAL))
                         if (AntispamInterface *a = sAnticheatLib->GetAntispam())

--- a/src/game/MapNodes/AbstractPlayer.cpp
+++ b/src/game/MapNodes/AbstractPlayer.cpp
@@ -13,6 +13,10 @@ uint32 PlayerWrapper<T>::GetZoneId() const { return player.GetZoneId(); }
 template <typename T>
 uint32 PlayerWrapper<T>::GetAreaId() const { return player.GetAreaId(); }
 template <typename T>
+uint32 PlayerWrapper<T>::GetCachedZoneId() const { return player.GetCachedZoneId(); }
+template <typename T>
+HonorRankInfo PlayerWrapper<T>::GetHonorRankInfo() const { return player.GetHonorRankInfo(); }
+template <typename T>
 uint8 PlayerWrapper<T>::getClass() const { return player.getClass(); }
 template <typename T>
 uint8 PlayerWrapper<T>::getRace() const { return player.getRace(); }

--- a/src/game/MapNodes/AbstractPlayer.h
+++ b/src/game/MapNodes/AbstractPlayer.h
@@ -28,6 +28,7 @@ class Player;
 class PlayerSocial;
 class WorldSession;
 class Channel;
+struct HonorRankInfo;
 
 class AbstractPlayer
 {
@@ -38,6 +39,8 @@ public:
     virtual const char* GetName() const = 0;
     virtual uint32 GetZoneId() const = 0;
     virtual uint32 GetAreaId() const = 0;
+    virtual uint32 GetCachedZoneId() const = 0;
+    virtual HonorRankInfo GetHonorRankInfo() const = 0;
     virtual uint8 getClass() const = 0;
     virtual uint8 getRace() const = 0;
     virtual uint32 getLevel() const = 0;
@@ -71,6 +74,8 @@ public:
     virtual const char* GetName() const;
     virtual uint32 GetZoneId() const;
     virtual uint32 GetAreaId() const;
+    virtual uint32 GetCachedZoneId() const;
+    virtual HonorRankInfo GetHonorRankInfo() const;
     virtual uint8 getClass() const;
     virtual uint8 getRace() const;
     virtual uint32 getLevel() const;

--- a/src/game/MapNodes/MasterPlayer.cpp
+++ b/src/game/MapNodes/MasterPlayer.cpp
@@ -42,6 +42,7 @@ void MasterPlayer::LoadPlayer(Player* player)
     name = player->GetName();
     zoneId = player->GetCachedZoneId();
     areaId = player->GetCachedAreaId();
+    m_honorRank = player->GetHonorRankInfo();
     raceId = player->getRace();
     classId = player->getClass();
     level = player->getLevel();

--- a/src/game/MapNodes/MasterPlayer.h
+++ b/src/game/MapNodes/MasterPlayer.h
@@ -112,6 +112,8 @@ public:
     const char* GetName() const { return name.c_str(); }
     uint32 GetZoneId() const { return zoneId; }
     uint32 GetAreaId() const { return areaId; }
+    uint32 GetCachedZoneId() const { return zoneId; }
+    HonorRankInfo GetHonorRankInfo() const { return m_honorRank; }
     uint8 getClass() const { return classId; }
     uint8 getRace() const { return raceId; }
     uint32 getLevel() const { return level; }
@@ -127,6 +129,7 @@ public:
     uint8 classId;
     uint32 level;
     Team m_team;
+    HonorRankInfo m_honorRank;
     // Guild system variables
     uint32 guildId;
     uint32 guildRank;

--- a/src/game/MapNodes/MasterPlayerChat.cpp
+++ b/src/game/MapNodes/MasterPlayerChat.cpp
@@ -108,6 +108,6 @@ void MasterPlayer::CleanupChannels()
         m_channels.erase(m_channels.begin());               // remove from player's channel list
         ch->Leave(GetObjectGuid(), false);                  // not send to client, not remove from player's channel list
         if (ChannelMgr* cMgr = channelMgr(GetTeam()))
-            cMgr->LeftChannel(ch->GetName());               // deleted channel if empty
+            cMgr->LeftChannel(ch->GetName(), sObjectAccessor.FindPlayerPointer(GetObjectGuid())); // deleted channel if empty
     }
 }

--- a/src/game/Objects/Player.cpp
+++ b/src/game/Objects/Player.cpp
@@ -4699,9 +4699,9 @@ void Player::CleanupChannels()
     {
         Channel* ch = *m_channels.begin();
         m_channels.erase(m_channels.begin());               // remove from player's channel list
-        ch->Leave(GetObjectGuid(), false);                  // not send to client, not remove from player's channel list
+        ch->Leave(GetObjectGuid(), ch->GetName().c_str(), false);   // not send to client, not remove from player's channel list
         if (ChannelMgr* cMgr = channelMgr(GetTeam()))
-            cMgr->LeftChannel(ch->GetName());               // deleted channel if empty
+            cMgr->LeftChannel(ch->GetName(), nullptr);      // deleted channel if empty
 
     }
     DEBUG_LOG("Player: channels cleaned up!");
@@ -4718,7 +4718,7 @@ void Player::LeaveLFGChannel()
     {
         if ((*i)->IsLFG())
         {
-            (*i)->Leave(GetObjectGuid());
+            (*i)->Leave(GetObjectGuid(), (*i)->GetName().c_str());
             break;
         }
     }

--- a/src/game/Objects/Player.h
+++ b/src/game/Objects/Player.h
@@ -1675,6 +1675,7 @@ class MANGOS_DLL_SPEC Player final: public Unit
 
         HonorMgr&       GetHonorMgr()       { return m_honorMgr; }
         HonorMgr const& GetHonorMgr() const { return m_honorMgr; }
+        HonorRankInfo GetHonorRankInfo() const { return m_honorMgr.GetRank(); }
 
         void UpdateSkillsForLevel();
         void UpdateSkillsToMaxSkillsForLevel();             // for .levelup


### PR DESCRIPTION
French, German, Spanish, English,... clients should be able to see what other write in general channels like Trade, Guild Recruitment, Local Defense...

Also in Defense channels, user rank should be displayed.

Basically, general channels are decoded using client locale and special names are used internally. When a message must be sent to the channel, it's decoded pet client locale to sent with the proper channel name for their localization.

Name decoding is based on AreaTable.dbc, so server must have all languages dbc to support them like this:
dbc/AreaTable.dbc <- the English one
dbc/frFR/AreaTable.dbc <- French one
dbc/deDE/AreaTable.dbc <- German one
...
You probably have them all already.

I could not use the AreaTable you moved to database since it's not localized.

Neo2003
Signed-off-by: Neo2003 <Neo.2003@Hotmail.fr>