### PR TITLE
Add 'Plans: Dark Iron Boots' to vendor list for 'Lokhtos Darkbargainer'

### DIFF
--- a/sql/migrations/20170324161850_world.sql
+++ b/sql/migrations/20170324161850_world.sql
@@ -1,0 +1,4 @@
+INSERT INTO `migrations` VALUES ('20170324161850');
+
+-- Add "Plans: Dark Iron Boots" to "Lokhtos Darkbargainer".
+INSERT INTO `npc_vendor` VALUES ('12944','20040','0','0');


### PR DESCRIPTION
Fixes issue https://github.com/elysium-project/server/issues/87

The plans are not present in the npc_vendor table at all, even though in the itemization patches there is a query to remove them in patches 1.2 and 1.3 - https://github.com/elysium-project/itemization/search?utf8=%E2%9C%93&q=20040&type=

Since the "base" world database is supposed to be for 1.12.1, they should be in the vendor list.