### PR TITLE
srand each time a new threadtask is started

### DIFF
--- a/src/shared/Threading.cpp
+++ b/src/shared/Threading.cpp
@@ -24,6 +24,7 @@
 #include <ace/OS_NS_unistd.h>
 #include <ace/Sched_Params.h>
 #include <vector>
+#include <chrono>
 
 using namespace ACE_Based;
 
@@ -188,6 +189,9 @@ void Thread::resume()
 
 ACE_THR_FUNC_RETURN Thread::ThreadTask(void * param)
 {
+    unsigned int seed = std::chrono::high_resolution_clock::now().time_since_epoch().count();
+    srand(seed);
+
     Runnable * _task = (Runnable*)param;
     _task->incReference();
     _task->run();


### PR DESCRIPTION
Please correct me if I'm wrong in any of this, but after struggling with extremely-not-random numbers from rand() calls in boss-scripts for a long time I started investigating, and after some of that I came to the following conclusions.

The core perform map updates in different threads all the time. First and foremost, rand() is not threadsafe.

> The function rand() is not reentrant or thread-safe, since it uses hidden state that is modified on each call. This might just be the seed value to be used by the next call, or it might be something more elaborate. In order to get reproducible behaviour in a threaded application, this state must be made explicit. The function  rand_r() is supplied with a pointer to an unsigned int, to be used as state. This is a very small amount of state, so this function will be a weak pseudo-random generator. Try  drand48_r(3) instead.

Though, I also read somewhere that vc++ c-runtime is threadsafe (windows), but:

> The srand function sets the starting point for generating a series of pseudorandom integers in the current thread.

Since the core use new threads all the time, the single srand in `World::SetInitialWorldSettings()` has absolutely no effect for map updates. Each time a new thread is spawned, and an update is executed on that new thread, even looking away from the reentrant or thread-safe issues, `rand()` will start over again with a new, default, uninitialized rand-table. 

Obviously, using modern, non `rand()`, c++ random generators is the real solution, but a quick-fix that at least makes the current rand() calls slightly more "random" could be the change suggested in this pull request.

This suggested hack-fix will, to my understanding (I don't really know how threads are handled in the core), seed new threads when they are started. I'm using the highest resolution 32 bits from `std::chrono::high_resolution_clock::now().time_since_epoch().count();`, so even if 10s of threads are spawned each second, they should each be getting their own `rand()` values. That is of course unless the reentrant or thread-safe issues just screw it completely up on non-windows platforms, in which case I'm wondering if simply redefining rand to rand_r on non windows platforms is an acceptable hack-fix.

`rand()` is used in quite a bit in boss-scripts, both directly and indirectly, so until someone replaces all of those with more modern and proper "random" functions, this could be a solution. Util.cpp seems to have some more proper random functions that seems to be based on a mersenne twister. It should not be too much work to replace all the rand() calls with these utility functions. However, for safety reasons, should someone screw up and use rand(),  I don't think it hurts to keep this hack-fix in place.