### PR TITLE
Fixed #98: Set bonus removal bug

### DIFF
--- a/src/game/Objects/Player.cpp
+++ b/src/game/Objects/Player.cpp
@@ -6740,7 +6740,7 @@ void Player::ApplyEquipSpell(SpellEntry const* spellInfo, Item* item, bool apply
         if (item)
             RemoveAurasDueToItemSpell(item, spellInfo->Id); // un-apply all spells , not only at-equipped
         else
-            RemoveAurasDueToSpell(spellInfo->Id);           // un-apply spell (item set case)
+            RemoveSingleAuraDueToItemSet(spellInfo->Id);    // un-apply spell (item set case)
     }
 }
 

--- a/src/game/Objects/Unit.cpp
+++ b/src/game/Objects/Unit.cpp
@@ -4413,6 +4413,21 @@ void Unit::RemoveAuraHolderFromStack(uint32 spellId, uint32 stackAmount, ObjectG
     }
 }
 
+void Unit::RemoveSingleAuraDueToItemSet(uint32 spellId, AuraRemoveMode mode)
+{
+    SpellAuraHolderBounds bounds = GetSpellAuraHolderBounds(spellId);
+    for (SpellAuraHolderMap::iterator iter = bounds.first; iter != bounds.second;)
+    {
+        if (!iter->second->GetCastItemGuid())
+        {
+            RemoveSpellAuraHolder(iter->second, mode);
+            return;
+        }
+        else
+            ++iter;
+    }
+}
+
 void Unit::RemoveAurasDueToSpell(uint32 spellId, SpellAuraHolder* except, AuraRemoveMode mode)
 {
     SpellAuraHolderBounds bounds = GetSpellAuraHolderBounds(spellId);

--- a/src/game/Objects/Unit.h
+++ b/src/game/Objects/Unit.h
@@ -1436,6 +1436,7 @@ class MANGOS_DLL_SPEC Unit : public WorldObject
         void RemoveSpellAuraHolder(SpellAuraHolder *holder, AuraRemoveMode mode = AURA_REMOVE_BY_DEFAULT);
         void RemoveSingleAuraFromSpellAuraHolder(SpellAuraHolder *holder, SpellEffectIndex index, AuraRemoveMode mode = AURA_REMOVE_BY_DEFAULT);
         void RemoveSingleAuraFromSpellAuraHolder(uint32 id, SpellEffectIndex index, ObjectGuid casterGuid, AuraRemoveMode mode = AURA_REMOVE_BY_DEFAULT);
+        void RemoveSingleAuraDueToItemSet(uint32 spellId, AuraRemoveMode mode = AURA_REMOVE_BY_DEFAULT);
 
         // Limit debuffs a 16
         uint32 GetNegativeAurasCount();


### PR DESCRIPTION
Related issues:
https://github.com/elysium-project/server/issues/98
https://elysium-project.org/bugtracker/issue/851
https://elysium-project.org/bugtracker/issue/1425
https://elysium-project.org/bugtracker/issue/3719

When unequipping a set bonus the _RemoveAurasDueToSpell_ function was being called, which removes multiple auras. 
For example if a 23 spell power bonus was unequipped, all 23 sp auras were removed from the character  including the ones from other gear.

Created a _RemoveSingleAuraDueToItemSet_ to solve the issue.