### PR TITLE
Shield Slam and Execute can now trigger Main Hand procs

### DIFF
--- a/src/game/Spells/Spell.cpp
+++ b/src/game/Spells/Spell.cpp
@@ -1167,7 +1167,10 @@ void Spell::DoAllEffectOnTarget(TargetInfo *target)
                 ((Player*)m_caster)->CastItemCombatSpell(unitTarget, m_attackType);
             // trigger mainhand weapon procs for shield attacks (Shield Bash, Shield Slam) NOTE: vanilla only mechanic, patched out in 2.0.1
             else if (m_spellInfo->EquippedItemClass == ITEM_CLASS_ARMOR && m_spellInfo->EquippedItemSubClassMask & (1 << ITEM_SUBCLASS_ARMOR_SHIELD)
-              && m_spellInfo->SpellIconID == 280)
+              && (m_spellInfo->SpellIconID == 280 || m_spellInfo->SpellIconID == 413))
+                ((Player*)m_caster)->CastItemCombatSpell(unitTarget, BASE_ATTACK);
+            // special case for Execute - it triggers another spell which does the actual damage
+            else if (m_spellInfo->Id == 20647)
                 ((Player*)m_caster)->CastItemCombatSpell(unitTarget, BASE_ATTACK);
             // special Paladin cases - trigger weapon procs despite not having EquippedItemClass
             else if (m_spellInfo->SpellFamilyName == SPELLFAMILY_PALADIN)


### PR DESCRIPTION
Fixes issues https://github.com/elysium-project/server/issues/174 and https://github.com/elysium-project/server/issues/181

This makes it so Shield Slam and Execute can trigger main hand procs.