### PR TITLE
Fix to raid markers disappearing (#194)

### DIFF
--- a/src/game/Group/Group.cpp
+++ b/src/game/Group/Group.cpp
@@ -1966,4 +1966,17 @@ void Group::UpdateLooterGuid(WorldObject* pLootedObject, bool ifneed)
         SetLooterGuid(0);
         SendUpdate();
     }
+
+    // SendUpdate clears the target icons, send an icon update
+    if (!isRaidGroup()) 
+    {
+        for (member_citerator citr = m_memberSlots.begin(); citr != m_memberSlots.end(); ++citr)
+        {
+            Player *player = sObjectMgr.GetPlayer(citr->guid);
+            if (!player || !player->GetSession() || player->GetGroup() != this)
+                continue;
+
+            SendTargetIconList(player->GetSession());
+        }
+    }
 }


### PR DESCRIPTION
https://github.com/elysium-project/server/issues/194

This issue happens because the UpdateLooterGuid method triggers a SendUpdate().
It seems like every time a _SMSG_GROUP_LIST_ message is sent to a non-raid group, the client is expecting the raid targets to be sent as well. Since none are ever sent the raid markers get cleared.

Ideally we would want to send the raid markers in the _SMSG_GROUP_LIST_ message, but I tested appending them to the end of the packet and it wasn't working. We would need to find out the exact structure of the _SMSG_GROUP_LIST_ packet.

The next best alternative is to send the target icons list to the player right after the SendUpdate().
It seems unecessary to do this on every SendUpdate call, so I did it only for the UpdateLooterGuid method.