### PR TITLE
SpellAuras: fixing shapeshifting + transform and stacked transforms (#245)

### DIFF
--- a/src/game/Spells/SpellAuras.cpp
+++ b/src/game/Spells/SpellAuras.cpp
@@ -2218,7 +2218,7 @@ void Aura::HandleAuraTransform(bool apply, bool Real)
     if (apply)
     {
         // Discombobulate removes mount auras.
-        if (GetId() == 4060)
+        if (GetId() == 4060 && Real)
             target->RemoveSpellsCausingAura(SPELL_AURA_MOUNTED);
         if (GetId() == 23603)   // Ustaag <Nostalrius> : Nefarian Class Call Mage
         {

--- a/src/game/Spells/SpellAuras.cpp
+++ b/src/game/Spells/SpellAuras.cpp
@@ -2081,7 +2081,6 @@ void Aura::HandleAuraModShapeshift(bool apply, bool Real)
         }
     }
 
-    sLog.outInfo("DEBUG %d %d %d %d", apply, Real, modelid, target->HasAuraType(SPELL_AURA_TRANSFORM));
     if (modelid > 0 && !target->getTransForm())
     {
         // fix Tauren shapeshift scaling

--- a/src/game/Spells/SpellAuras.cpp
+++ b/src/game/Spells/SpellAuras.cpp
@@ -2410,7 +2410,7 @@ void Aura::HandleAuraTransform(bool apply, bool Real)
                 }
                 
                 Unit::AuraList const& shapeshift = target->GetAurasByType(SPELL_AURA_MOD_SHAPESHIFT);
-                if (!shapeshift.empty())
+                if (!shapeshift.empty() && !shapeshift.front()->IsInUse())
                     shapeshift.front()->HandleAuraModShapeshift(true,false);
             }
         }

--- a/src/game/Spells/SpellAuras.cpp
+++ b/src/game/Spells/SpellAuras.cpp
@@ -2361,17 +2361,6 @@ void Aura::HandleAuraTransform(bool apply, bool Real)
         //reset cosmetics only if it's the current transform
         if (target->getTransForm() == GetId())
         {
-            //fix tauren scaling
-            if (target->getRace() == RACE_TAUREN)
-            {
-                float mod_x = 0;
-                if (target->getGender() == GENDER_MALE)
-                    mod_x = -25.9f; // 0.741 * 1.35 ~= 1.0
-                else
-                    mod_x = -20.0f; // 0.8 * 1.25    = 1.0
-                target->ApplyPercentModFloatValue(OBJECT_FIELD_SCALE_X, mod_x, apply);
-            }
-        
             target->setTransForm(0);
             target->SetDisplayId(target->GetNativeDisplayId());
 
@@ -2383,6 +2372,17 @@ void Aura::HandleAuraTransform(bool apply, bool Real)
             Unit::AuraList const& otherTransforms = target->GetAurasByType(SPELL_AURA_TRANSFORM);
             if (!otherTransforms.empty())
             {
+                //fix tauren scaling
+                if (target->getRace() == RACE_TAUREN && target->GetShapeshiftForm() == FORM_NONE)
+                {
+                    float mod_x = 0;
+                    if (target->getGender() == GENDER_MALE)
+                        mod_x = -25.9f; // 0.741 * 1.35 ~= 1.0
+                    else
+                        mod_x = -20.0f; // 0.8 * 1.25    = 1.0
+                    target->ApplyPercentModFloatValue(OBJECT_FIELD_SCALE_X, mod_x, apply);
+                }
+            
                 // look for other transform auras
                 Aura* handledAura = *otherTransforms.rbegin();
                 for (Unit::AuraList::const_reverse_iterator i = otherTransforms.rbegin(); i != otherTransforms.rend(); ++i)
@@ -2398,6 +2398,17 @@ void Aura::HandleAuraTransform(bool apply, bool Real)
             }
             else //reapply shapeshifting, there should be only one.
             {
+                //fix tauren scaling
+                if (target->getRace() == RACE_TAUREN)
+                {
+                    float mod_x = 0;
+                    if (target->getGender() == GENDER_MALE)
+                        mod_x = -25.9f; // 0.741 * 1.35 ~= 1.0
+                    else
+                        mod_x = -20.0f; // 0.8 * 1.25    = 1.0
+                    target->ApplyPercentModFloatValue(OBJECT_FIELD_SCALE_X, mod_x, apply);
+                }
+                
                 Unit::AuraList const& shapeshift = target->GetAurasByType(SPELL_AURA_MOD_SHAPESHIFT);
                 if (!shapeshift.empty())
                     shapeshift.front()->HandleAuraModShapeshift(true,false);

--- a/src/game/Spells/SpellAuras.cpp
+++ b/src/game/Spells/SpellAuras.cpp
@@ -2070,10 +2070,6 @@ void Aura::HandleAuraModShapeshift(bool apply, bool Real)
                     iter = slowingAuras.begin();
                 }
 
-                // and polymorphic affects
-                if (target->IsPolymorphed())
-                    target->RemoveAurasDueToSpell(target->getTransForm());
-
                 break;
             }
             default:


### PR DESCRIPTION
- transform:
    - ApplyModifier checks if the aura is applied, which is always true for transforms effects, use directly HandleAuraTransform to skip the checks.
    - When removing last transform, reapply shapeshifting (if any).

- shapeshift:
    - use Real guard to split ability and display effects

I don't have any knowledge of mangos, but using handles directly looks like a workaround to make another workaround working to me. Well at least now it should work.