### PR TITLE
Bug #3356 - Gromsblood spawn below terrain

### DIFF
--- a/sql/migrations/20170331201306_world.sql
+++ b/sql/migrations/20170331201306_world.sql
@@ -1,0 +1,4 @@
+INSERT INTO `migrations` VALUES ('20170331201306');
+
+-- Gromsblood spawn in Blasted Lands was spawning below the terrain
+UPDATE gameobject SET position_z = 14.5 WHERE guid = 32304


### PR DESCRIPTION
https://elysium-project.org/bugtracker/issue/3356

The position_z of this object is too low so it falls below the terrain. Increasing it to 14.5 puts it neatly on the ground.