### PR TITLE
Fixes transportation issues on MacOS #2

### DIFF
--- a/src/game/Handlers/CharacterHandler.cpp
+++ b/src/game/Handlers/CharacterHandler.cpp
@@ -795,15 +795,6 @@ void WorldSession::HandleMeetingStoneInfoOpcode(WorldPacket & /*recv_data*/)
     WorldPacket data(SMSG_MEETINGSTONE_SETQUEUE, 5);
     data << uint32(0) << uint8(6);
     SendPacket(&data);
-
-    // Trigger a client camera reset by sending an `SMSG_STANDSTATE_UPDATE'
-    // event. See `WorldSession::HandleMoveWorldportAckOpcode'.
-    if (GetPlayer()->m_movementInfo.HasMovementFlag(MOVEFLAG_ONTRANSPORT))
-    {
-        WorldPacket data(SMSG_STANDSTATE_UPDATE, 1);
-        data << GetPlayer()->getStandState();
-        GetPlayer()->GetSession()->SendPacket(&data);
-    }
 }
 
 void WorldSession::HandleTutorialFlagOpcode(WorldPacket & recv_data)

--- a/src/game/Handlers/MiscHandler.cpp
+++ b/src/game/Handlers/MiscHandler.cpp
@@ -414,6 +414,16 @@ void WorldSession::HandleZoneUpdateOpcode(WorldPacket & recv_data)
     uint32 newzone, newarea;
     GetPlayer()->GetZoneAndAreaId(newzone, newarea);
     GetPlayer()->UpdateZone(newzone, newarea);
+
+    // Trigger a client camera reset by sending an `SMSG_STANDSTATE_UPDATE'
+    // event. See `WorldSession::HandleMoveWorldportAckOpcode'.
+    // Note: There might be a better place to perform this trigger
+    if (GetPlayer()->m_movementInfo.HasMovementFlag(MOVEFLAG_ONTRANSPORT))
+    {
+        WorldPacket data(SMSG_STANDSTATE_UPDATE, 1);
+        data << GetPlayer()->getStandState();
+        GetPlayer()->GetSession()->SendPacket(&data);
+    }
 }
 
 void WorldSession::HandleSetTargetOpcode(WorldPacket & recv_data)
@@ -752,7 +762,7 @@ void WorldSession::HandleAreaTriggerOpcode(WorldPacket & recv_data)
                 pl->AreaExploredOrEventHappens(quest_id);
         }
     }
-    
+
     // enter to tavern, not overwrite city rest
     if (sObjectMgr.IsTavernAreaTrigger(Trigger_ID))
     {

--- a/src/game/Handlers/MovementHandler.cpp
+++ b/src/game/Handlers/MovementHandler.cpp
@@ -212,8 +212,8 @@ void WorldSession::HandleMoveWorldportAckOpcode()
     // On a successful port, the camera of the MacOS client is facing south and
     // ignores any movement from the transport object. Triggering
     // `SMSG_STANDSTATE_UPDATE' with its current state resets the camera
-    // (implemented in `WorldSession::HandleMeetingStoneInfoOpcode').
-    GetPlayer()->SendHeartBeat(false);
+    // (implemented in `WorldSession::HandleZoneUpdateOpcode').
+    GetPlayer()->SendHeartBeat(true);
 }
 
 void WorldSession::HandleMoveTeleportAckOpcode(WorldPacket& recv_data)

--- a/src/game/PacketBroadcast/PlayerBroadcaster.h
+++ b/src/game/PacketBroadcast/PlayerBroadcaster.h
@@ -38,7 +38,9 @@ class PlayerBroadcaster final
 
     static inline bool CanSkipPacket(uint32 opcode)
     {
-        return opcode < MSG_MOVE_SET_RUN_SPEED_CHEAT || opcode > MSG_MOVE_SET_TURN_RATE;
+        return (opcode < MSG_MOVE_SET_RUN_SPEED_CHEAT ||
+                (opcode > MSG_MOVE_SET_TURN_RATE &&
+                 opcode != MSG_MOVE_HEARTBEAT));
     }
 
     uint32 instanceId;


### PR DESCRIPTION
This pull request is a follow-up to #89 which appeared to bring back the 'old' horrors of random teleportation in production.

#89 didn't cover the situation with dedicated threads for packet broadcasting (`Network.PacketBroadcast.Threads`). In addition to that, the heartbeat "self" flag should have been set to true. The heartbeat was being passed to the client without any dedicated threads because of `Object.cpp:1882` (`SendObjectMessageToSet(&data, true, except);`) which forced the "self" flag to be true. This led to a scenario that worked despite having the "self" flag set to false until... `Network.PacketBroadcast.Threads` was configured differently in production.

With broadcast threading, there is a small chance that the heartbeat packet can be skipped (if the outgoing packet queue is full) and cause the random teleportation. The change of conditions in `CanSkipPacket` attempts to avoid this.

Camera is still an issue, and is now handled upon `HandleZoneUpdateOpcode` instead. `HandleMeetingStoneInfoOpcode` fired too early and only worked 60% of the time.