### PR TITLE
Use Spell Focus as effect for Spirit of Aquamentas

### DIFF
--- a/sql/migrations/20170402195949_world.sql
+++ b/sql/migrations/20170402195949_world.sql
@@ -1,0 +1,4 @@
+INSERT INTO `migrations` VALUES ('20170402195949');
+
+-- Change Spirit of Aquamentas to decrease spells mana costs
+UPDATE `item_template` SET `spellid_1`=12854 WHERE `entry`=11904;


### PR DESCRIPTION
The item [*Spirit of Aquamentas*](http://db.vanillagaming.org/?item=11904) does not function as described by the tooltip.

![image](https://cloud.githubusercontent.com/assets/1612390/24589810/604ad552-17e1-11e7-904f-53ffad50fd26.png)

Instead it increases the damage and healing of spells by 20.
The misinformation provided by the tooltip causes much confusion (see among others [#2792](https://elysium-project.org/bugtracker/issue/2792)).