### PR TITLE
Improve regen accuracy

### DIFF
--- a/src/game/Objects/Creature.cpp
+++ b/src/game/Objects/Creature.cpp
@@ -721,14 +721,9 @@ void Creature::StopGroupLoot()
 
 void Creature::RegenerateAll(uint32 update_diff, bool skipCombatCheck)
 {
+    m_regenTimer -= update_diff;
+
     if (m_regenTimer > 0)
-    {
-        if (update_diff >= m_regenTimer)
-            m_regenTimer = 0;
-        else
-            m_regenTimer -= update_diff;
-    }
-    if (m_regenTimer != 0)
         return;
 
     if (!isInCombat() || IsPolymorphed() || skipCombatCheck)

--- a/src/game/Objects/Player.cpp
+++ b/src/game/Objects/Player.cpp
@@ -1226,13 +1226,7 @@ void Player::Update(uint32 update_diff, uint32 p_time)
         }
     }
 
-    if (m_regenTimer)
-    {
-        if (update_diff >= m_regenTimer)
-            m_regenTimer = 0;
-        else
-            m_regenTimer -= update_diff;
-    }
+    m_regenTimer -= update_diff;
 
     if (m_weaponChangeTimer > 0)
     {
@@ -2167,7 +2161,7 @@ void Player::RewardRage(uint32 damage, bool attacker)
 
 void Player::RegenerateAll()
 {
-    if (m_regenTimer != 0)
+    if (m_regenTimer > 0)
         return;
 
     // Not in combat or they have regeneration
@@ -2183,7 +2177,7 @@ void Player::RegenerateAll()
 
     Regenerate(POWER_MANA);
 
-    m_regenTimer = REGEN_TIME_FULL;
+    m_regenTimer += REGEN_TIME_FULL;
 }
 
 void Player::Regenerate(Powers power)

--- a/src/game/Objects/Unit.h
+++ b/src/game/Objects/Unit.h
@@ -1952,7 +1952,7 @@ class MANGOS_DLL_SPEC Unit : public WorldObject
 
         uint32 m_reactiveTimer[MAX_REACTIVE];
         ObjectGuid m_reactiveTarget[MAX_REACTIVE];
-        uint32 m_regenTimer;
+        int32 m_regenTimer;
         uint32 m_lastManaUseTimer;
 
         SpellCooldowns m_spellCooldowns;


### PR DESCRIPTION
Changed the timing for health/mana/energy/rage generation to allow negative values. Any negative value will effectively be subtracted from the time until the next regeneration tick, thus reducing drift/error over time, especially on servers with higher load.

This should also fix an issue with Evocation reported at https://elysium-project.org/bugtracker/issue/824