### PR TITLE
Fix for the Elemental Charms from Arathi Highlands

### DIFF
--- a/sql/migrations/20170410044436_world.sql
+++ b/sql/migrations/20170410044436_world.sql
@@ -4,3 +4,6 @@ INSERT INTO `migrations` VALUES ('20170410044436');
 UPDATE `spell_effect_mod` SET `Effect`=1 WHERE `entry`=4131;
 INSERT INTO `spell_effect_mod` (`Id`, `EffectIndex`, `Effect`, `EffectDieSides`, `EffectBaseDice`, `EffectDicePerLevel`, `EffectRealPointsPerLevel`, `EffectBasePoints`, `EffectAmplitude`, `EffectPointsPerComboPoint`, `EffectChainTarget`, `EffectMultipleValue`, `EffectMechanic`, `EffectImplicitTargetA`, `EffectImplicitTargetB`, `EffectRadiusIndex`, `EffectApplyAuraName`, `EffectItemType`, `EffectMiscValue`, `EffectTriggerSpell`, `Comment`) VALUES (4130, 0, 1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 38, 0, -1, -1, -1, 0, -1, 'Arathi Cresting Charm');
 INSERT INTO `spell_effect_mod` (`Id`, `EffectIndex`, `Effect`, `EffectDieSides`, `EffectBaseDice`, `EffectDicePerLevel`, `EffectRealPointsPerLevel`, `EffectBasePoints`, `EffectAmplitude`, `EffectPointsPerComboPoint`, `EffectChainTarget`, `EffectMultipleValue`, `EffectMechanic`, `EffectImplicitTargetA`, `EffectImplicitTargetB`, `EffectRadiusIndex`, `EffectApplyAuraName`, `EffectItemType`, `EffectMiscValue`, `EffectTriggerSpell`, `Comment`) VALUES (4132, 0, 1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 38, 0, -1, -1, -1, 0, -1, 'Arathi Burning Charm');
+
+-- Fix db errors. Targets are already defined in `spell_script_target`.
+DELETE FROM `item_required_target` WHERE `entry` IN (4479, 4480, 4481);

--- a/sql/migrations/20170410044436_world.sql
+++ b/sql/migrations/20170410044436_world.sql
@@ -1,0 +1,6 @@
+INSERT INTO `migrations` VALUES ('20170410044436'); 
+
+-- Fix Thundering Charm, Burning Charm and Cresting Charm
+UPDATE `spell_effect_mod` SET `Effect`=1 WHERE `entry`=4131;
+INSERT INTO `spell_effect_mod` (`Id`, `EffectIndex`, `Effect`, `EffectDieSides`, `EffectBaseDice`, `EffectDicePerLevel`, `EffectRealPointsPerLevel`, `EffectBasePoints`, `EffectAmplitude`, `EffectPointsPerComboPoint`, `EffectChainTarget`, `EffectMultipleValue`, `EffectMechanic`, `EffectImplicitTargetA`, `EffectImplicitTargetB`, `EffectRadiusIndex`, `EffectApplyAuraName`, `EffectItemType`, `EffectMiscValue`, `EffectTriggerSpell`, `Comment`) VALUES (4130, 0, 1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 38, 0, -1, -1, -1, 0, -1, 'Arathi Cresting Charm');
+INSERT INTO `spell_effect_mod` (`Id`, `EffectIndex`, `Effect`, `EffectDieSides`, `EffectBaseDice`, `EffectDicePerLevel`, `EffectRealPointsPerLevel`, `EffectBasePoints`, `EffectAmplitude`, `EffectPointsPerComboPoint`, `EffectChainTarget`, `EffectMultipleValue`, `EffectMechanic`, `EffectImplicitTargetA`, `EffectImplicitTargetB`, `EffectRadiusIndex`, `EffectApplyAuraName`, `EffectItemType`, `EffectMiscValue`, `EffectTriggerSpell`, `Comment`) VALUES (4132, 0, 1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 38, 0, -1, -1, -1, 0, -1, 'Arathi Burning Charm');


### PR DESCRIPTION
The elemental exiles in Arathi Highlands drop charms, which are supposed to kill the opposite kind of elemental. They had their targets set correctly in the database, but the effect was missing so they were bugged. This fixes them.

http://db.vanillagaming.org/?item=4479
http://db.vanillagaming.org/?item=4480
http://db.vanillagaming.org/?item=4481