### PR TITLE
Sweeping strikes fixes.

### DIFF
--- a/src/game/Spells/Spell.cpp
+++ b/src/game/Spells/Spell.cpp
@@ -3190,7 +3190,7 @@ void Spell::cast(bool skipCheck)
 		}
 
 
-		if (m_spellInfo->Id == 20569)                   //Cleave
+		if (m_spellInfo->Id == 20569 || m_spellInfo->Id == 845 || m_spellInfo->Id == 7369 || m_spellInfo->Id == 11608 || m_spellInfo->Id == 11609)  //Cleave all ranks
 		{
 			if (m_caster->GetAura(12292, EFFECT_INDEX_0)) //Sweeping Strike
 			{

--- a/src/game/Spells/Spell.cpp
+++ b/src/game/Spells/Spell.cpp
@@ -3159,55 +3159,54 @@ void Spell::cast(bool skipCheck)
 
             break;
         }
-     	case SPELLFAMILY_WARRIOR:
-	{
-		if (m_spellInfo->Id == 1680)                   //Whirlwind
-		{
-			if (m_caster->GetAura(12292, EFFECT_INDEX_0)) //Sweeping Strike
-				{
+	case SPELLFAMILY_WARRIOR:
+        {
+            if (m_spellInfo->Id == 1680)                   //Whirlwind
+            {
+                if (m_caster->GetAura(12292, EFFECT_INDEX_0)) //Sweeping Strike
+                    {
 
-			//This handles removal of one stack and makes sure it doesn't remove a stack if whirlwind doesn't hit anything.
-			SpellAuraProcResult unit(Unit *pVictim, uint32 damage, Aura* triggeredByAura, SpellEntry const * procSpell, uint32 procFlag, uint32 procEx, uint32 cooldown);
-					{
-					Aura* sweepingStrikeAura = m_caster->GetAura(12292, EFFECT_INDEX_0);
-					SpellAuraHolder* sweepingStrikeHolder = sweepingStrikeAura->GetHolder();
-					int32 CurrentCharges = sweepingStrikeHolder->GetAuraCharges();
+                    //This handles removal of one stack and makes sure it doesn't remove a stack if whirlwind doesn't hit anything.
+                        Aura* sweepingStrikeAura = m_caster->GetAura(12292, EFFECT_INDEX_0);
+                        SpellAuraHolder* sweepingStrikeHolder = sweepingStrikeAura->GetHolder();
+                        int32 CurrentCharges = sweepingStrikeHolder->GetAuraCharges();
 
-					Unit* pVictim;
-					Unit* target = pVictim;
-					//Adjusting range for the range of whirlwind to remove a charge (not litterly the range of whirlwind, just for how far the target can be away to drop a charge).
-					target = m_caster->SelectRandomUnfriendlyTarget(pVictim,8);
+                        Unit* pVictim;
+                        Unit* target = pVictim;
 
-					if (target)
-					{
-						sweepingStrikeHolder->SetAuraCharges(CurrentCharges - 1);
-					}
+                        //Adjusting range for the range of whirlwind to remove a charge (not litterly the range of whirlwind, just for how far the target can be away to drop a charge).
+                        target = m_caster->SelectRandomUnfriendlyTarget(pVictim, 8);
 
-
-					}
-				}
-		break;
-		}
+                        if (target)
+                        {
+                            sweepingStrikeHolder->SetAuraCharges(CurrentCharges - 1);
+                        }
 
 
-		if (m_spellInfo->Id == 20569 || m_spellInfo->Id == 845 || m_spellInfo->Id == 7369 || m_spellInfo->Id == 11608 || m_spellInfo->Id == 11609)  //Cleave all ranks
-		{
-			if (m_caster->GetAura(12292, EFFECT_INDEX_0)) //Sweeping Strike
-			{
-				//This handles removal of one charge for sweepingstrike
-				SpellAuraProcResult unit(Unit *pVictim, uint32 damage, Aura* triggeredByAura, SpellEntry const * procSpell, uint32 procFlag, uint32 procEx, uint32 cooldown);
-				{
-					Aura* sweepingStrikeAura = m_caster->GetAura(12292, EFFECT_INDEX_0);
-					SpellAuraHolder* sweepingStrikeHolder = sweepingStrikeAura->GetHolder();
-					int32 CurrentCharges = sweepingStrikeHolder->GetAuraCharges();
-					sweepingStrikeHolder->SetAuraCharges(CurrentCharges - 1);
+                    }
+            break;
+            }
+            
+        
+            if (m_spellInfo->Id == 20569 || m_spellInfo->Id == 845 || m_spellInfo->Id == 7369 || m_spellInfo->Id == 11608 || m_spellInfo->Id == 11609)  //Cleave all ranks
+                                                                                                                                                                         
+            {
+                if (m_caster->GetAura(12292, EFFECT_INDEX_0)) //Sweeping Strike
+                {
+                    //This handles removal of one charge for sweepingstrike
 
-				}
-			}
+                        Aura* sweepingStrikeAura = m_caster->GetAura(12292, EFFECT_INDEX_0);
+                        SpellAuraHolder* sweepingStrikeHolder = sweepingStrikeAura->GetHolder();
+                        int32 CurrentCharges = sweepingStrikeHolder->GetAuraCharges();
 
-		}
-		break;
-	}
+                        sweepingStrikeHolder->SetAuraCharges(CurrentCharges - 1);
+
+                    
+                }
+                
+            }
+            break;
+        }
         case SPELLFAMILY_PRIEST:
         {
             // Power Word: Shield

--- a/src/game/Spells/Spell.cpp
+++ b/src/game/Spells/Spell.cpp
@@ -3161,13 +3161,22 @@ void Spell::cast(bool skipCheck)
         }
 	case SPELLFAMILY_WARRIOR:
         {
-            if (m_spellInfo->Id == 1680)                   //Whirlwind
+            int WhirlWind = 1680;
+            int SweepingStrikeAuraID = 12292;
+            int CleaveRank1 = 845;
+            int CleaveRank2 = 7369;
+            int CleaveRank3 = 11608;
+            int CleaveRank4 = 11609;
+            int CleaveRank5 = 20569;
+
+            if (m_spellInfo->Id == WhirlWind)                   //Whirlwind
             {
-                if (m_caster->GetAura(12292, EFFECT_INDEX_0)) //Sweeping Strike
+                if (m_caster->GetAura(SweepingStrikeAuraID, EFFECT_INDEX_0)) //Sweeping Strike
                     {
 
                     //This handles removal of one stack and makes sure it doesn't remove a stack if whirlwind doesn't hit anything.
-                        Aura* sweepingStrikeAura = m_caster->GetAura(12292, EFFECT_INDEX_0);
+
+                        Aura* sweepingStrikeAura = m_caster->GetAura(SweepingStrikeAuraID, EFFECT_INDEX_0);
                         SpellAuraHolder* sweepingStrikeHolder = sweepingStrikeAura->GetHolder();
                         int32 CurrentCharges = sweepingStrikeHolder->GetAuraCharges();
 
@@ -3186,16 +3195,17 @@ void Spell::cast(bool skipCheck)
                     }
             break;
             }
+
             
         
-            if (m_spellInfo->Id == 20569 || m_spellInfo->Id == 845 || m_spellInfo->Id == 7369 || m_spellInfo->Id == 11608 || m_spellInfo->Id == 11609)  //Cleave all ranks
+            if (m_spellInfo->Id == CleaveRank1 || m_spellInfo->Id == CleaveRank2 || m_spellInfo->Id == CleaveRank3 || m_spellInfo->Id == CleaveRank4 || m_spellInfo->Id == CleaveRank5)  //Cleave all ranks
                                                                                                                                                                          
             {
-                if (m_caster->GetAura(12292, EFFECT_INDEX_0)) //Sweeping Strike
+                if (m_caster->GetAura(SweepingStrikeAuraID, EFFECT_INDEX_0)) //Sweeping Strike
                 {
                     //This handles removal of one charge for sweepingstrike
 
-                        Aura* sweepingStrikeAura = m_caster->GetAura(12292, EFFECT_INDEX_0);
+                        Aura* sweepingStrikeAura = m_caster->GetAura(SweepingStrikeAuraID, EFFECT_INDEX_0);
                         SpellAuraHolder* sweepingStrikeHolder = sweepingStrikeAura->GetHolder();
                         int32 CurrentCharges = sweepingStrikeHolder->GetAuraCharges();
 

--- a/src/game/Spells/Spell.cpp
+++ b/src/game/Spells/Spell.cpp
@@ -3159,64 +3159,6 @@ void Spell::cast(bool skipCheck)
 
             break;
         }
-	case SPELLFAMILY_WARRIOR:
-        {
-            int WhirlWind = 1680;
-            int SweepingStrikeAuraID = 12292;
-            int CleaveRank1 = 845;
-            int CleaveRank2 = 7369;
-            int CleaveRank3 = 11608;
-            int CleaveRank4 = 11609;
-            int CleaveRank5 = 20569;
-
-            if (m_spellInfo->Id == WhirlWind)                   //Whirlwind
-            {
-                if (m_caster->GetAura(SweepingStrikeAuraID, EFFECT_INDEX_0)) //Sweeping Strike
-                    {
-
-                    //This handles removal of one stack and makes sure it doesn't remove a stack if whirlwind doesn't hit anything.
-
-                        Aura* sweepingStrikeAura = m_caster->GetAura(SweepingStrikeAuraID, EFFECT_INDEX_0);
-                        SpellAuraHolder* sweepingStrikeHolder = sweepingStrikeAura->GetHolder();
-                        int32 CurrentCharges = sweepingStrikeHolder->GetAuraCharges();
-
-                        Unit* pVictim;
-                        Unit* target = pVictim;
-
-                        //Adjusting range for the range of whirlwind to remove a charge (not litterly the range of whirlwind, just for how far the target can be away to drop a charge).
-                        target = m_caster->SelectRandomUnfriendlyTarget(pVictim, 8);
-
-                        if (target)
-                        {
-                            sweepingStrikeHolder->SetAuraCharges(CurrentCharges - 1);
-                        }
-
-
-                    }
-            break;
-            }
-
-            
-        
-            if (m_spellInfo->Id == CleaveRank1 || m_spellInfo->Id == CleaveRank2 || m_spellInfo->Id == CleaveRank3 || m_spellInfo->Id == CleaveRank4 || m_spellInfo->Id == CleaveRank5)  //Cleave all ranks
-                                                                                                                                                                         
-            {
-                if (m_caster->GetAura(SweepingStrikeAuraID, EFFECT_INDEX_0)) //Sweeping Strike
-                {
-                    //This handles removal of one charge for sweepingstrike
-
-                        Aura* sweepingStrikeAura = m_caster->GetAura(SweepingStrikeAuraID, EFFECT_INDEX_0);
-                        SpellAuraHolder* sweepingStrikeHolder = sweepingStrikeAura->GetHolder();
-                        int32 CurrentCharges = sweepingStrikeHolder->GetAuraCharges();
-
-                        sweepingStrikeHolder->SetAuraCharges(CurrentCharges - 1);
-
-                    
-                }
-                
-            }
-            break;
-        }
         case SPELLFAMILY_PRIEST:
         {
             // Power Word: Shield

--- a/src/game/Spells/Spell.cpp
+++ b/src/game/Spells/Spell.cpp
@@ -3159,8 +3159,55 @@ void Spell::cast(bool skipCheck)
 
             break;
         }
-        case SPELLFAMILY_WARRIOR:
-            break;
+     	case SPELLFAMILY_WARRIOR:
+	{
+		if (m_spellInfo->Id == 1680)                   //Whirlwind
+		{
+			if (m_caster->GetAura(12292, EFFECT_INDEX_0)) //Sweeping Strike
+				{
+
+			//This handles removal of one stack and makes sure it doesn't remove a stack if whirlwind doesn't hit anything.
+			SpellAuraProcResult unit(Unit *pVictim, uint32 damage, Aura* triggeredByAura, SpellEntry const * procSpell, uint32 procFlag, uint32 procEx, uint32 cooldown);
+					{
+					Aura* sweepingStrikeAura = m_caster->GetAura(12292, EFFECT_INDEX_0);
+					SpellAuraHolder* sweepingStrikeHolder = sweepingStrikeAura->GetHolder();
+					int32 CurrentCharges = sweepingStrikeHolder->GetAuraCharges();
+
+					Unit* pVictim;
+					Unit* target = pVictim;
+					//Adjusting range for the range of whirlwind to remove a charge (not litterly the range of whirlwind, just for how far the target can be away to drop a charge).
+					target = m_caster->SelectRandomUnfriendlyTarget(pVictim,8);
+
+					if (target)
+					{
+						sweepingStrikeHolder->SetAuraCharges(CurrentCharges - 1);
+					}
+
+
+					}
+				}
+		break;
+		}
+
+
+		if (m_spellInfo->Id == 20569)                   //Cleave
+		{
+			if (m_caster->GetAura(12292, EFFECT_INDEX_0)) //Sweeping Strike
+			{
+				//This handles removal of one charge for sweepingstrike
+				SpellAuraProcResult unit(Unit *pVictim, uint32 damage, Aura* triggeredByAura, SpellEntry const * procSpell, uint32 procFlag, uint32 procEx, uint32 cooldown);
+				{
+					Aura* sweepingStrikeAura = m_caster->GetAura(12292, EFFECT_INDEX_0);
+					SpellAuraHolder* sweepingStrikeHolder = sweepingStrikeAura->GetHolder();
+					int32 CurrentCharges = sweepingStrikeHolder->GetAuraCharges();
+					sweepingStrikeHolder->SetAuraCharges(CurrentCharges - 1);
+
+				}
+			}
+
+		}
+		break;
+	}
         case SPELLFAMILY_PRIEST:
         {
             // Power Word: Shield

--- a/src/game/UnitAuraProcHandler.cpp
+++ b/src/game/UnitAuraProcHandler.cpp
@@ -444,9 +444,26 @@ SpellAuraProcResult Unit::HandleDummyAuraProc(Unit *pVictim, uint32 damage, Aura
                     triggered_spell_id = 25997;
                     break;
                 }
-                // Sweeping Strikes
+            //Sweeping strikes NPCS
+            case 18765:
+                {
+                    // prevent chain of triggered spell from same triggered spell
+                    if (procSpell && procSpell->Id == 26654)
+                    {
+                        return SPELL_AURA_PROC_FAILED;
+                    }
+
+                    target = SelectRandomUnfriendlyTarget(pVictim);
+                    if (!target)
+                    {
+                        return SPELL_AURA_PROC_FAILED;
+                    }
+
+                    triggered_spell_id = 26654;
+                    break;
+                }
+                // Sweeping Strikes players
                 case 12292:
-                case 18765:
                 {
                     /*
                     Please note that UnitAuraProcHandler is not made to handle interactions like sweeping strike + Whirlwind/Cleave at all

--- a/src/game/UnitAuraProcHandler.cpp
+++ b/src/game/UnitAuraProcHandler.cpp
@@ -452,7 +452,7 @@ SpellAuraProcResult Unit::HandleDummyAuraProc(Unit *pVictim, uint32 damage, Aura
 			Please note that UnitAuraProcHandler is not made to handle interactions like sweeping strike + Whirlwind/Cleave at all
 			reason being that UnitAuraProcHandler process the case for each hit and not per ability which results in a charge dropped per hit.
 			Instead modification to Spell.cpp has been made for whirlwind (SPELLFAMILY_WARRIOR) and cleave which handles the charge withdrawlas.
-			1 Charge is always withdrawn everytime you use whirlwind from spell.cpp
+			1 Charge is always withdrawn everytime you use whirlwind from spell.cpp which is why you will +1 added charges in the prochandler here.
 			*/
 
 			//Fetch sweeping strike aura for being able to get and modify the amount the charges.

--- a/src/game/UnitAuraProcHandler.cpp
+++ b/src/game/UnitAuraProcHandler.cpp
@@ -452,7 +452,7 @@ SpellAuraProcResult Unit::HandleDummyAuraProc(Unit *pVictim, uint32 damage, Aura
 			Please note that UnitAuraProcHandler is not made to handle interactions like sweeping strike + Whirlwind/Cleave at all
 			reason being that UnitAuraProcHandler process the case for each hit and not per ability which results in a charge dropped per hit.
 			Instead modification to Spell.cpp has been made for whirlwind (SPELLFAMILY_WARRIOR) and cleave which handles the charge withdrawlas.
-			1 Charge is always withdrawn everytime you use whirlwind from spell.cpp which is why you will +1 added charges in the prochandler here.
+			1 Charge is always withdrawn everytime you use whirlwind from spell.cpp which is why you will see +1 add charges in the prochandler here.
 			*/
 
 			//Fetch sweeping strike aura for being able to get and modify the amount the charges.

--- a/src/game/UnitAuraProcHandler.cpp
+++ b/src/game/UnitAuraProcHandler.cpp
@@ -444,7 +444,8 @@ SpellAuraProcResult Unit::HandleDummyAuraProc(Unit *pVictim, uint32 damage, Aura
                     triggered_spell_id = 25997;
                     break;
                 }
-		case 12292:
+                // Sweeping Strikes
+                case 12292:
                 case 18765:
                 {
                     /*
@@ -454,28 +455,42 @@ SpellAuraProcResult Unit::HandleDummyAuraProc(Unit *pVictim, uint32 damage, Aura
                     1 Charge is always withdrawn everytime you use whirlwind or charge from spell.cpp which is why you will see +1 add charges in the prochandler here.
                     */
 
+                    // Spells
+                    int sweepingStrikeProcAA = 26654;
+                    int SweepingStrikeProc = 12723;
+                    int SweepingStrikeAuraID = 12292;
+                    int WhirlWind = 1680;
+                    int CleaveRank1 = 845;
+                    int CleaveRank2 = 7369;
+                    int CleaveRank3 = 11608;
+                    int CleaveRank4 = 11609;
+                    int CleaveRank5 = 20569;
+                    int Execute = 20647;
+                    //
+
                     //Fetch sweeping strike aura for being able to get and modify the amount the charges.
-                    Aura* sweepingStrikeAura = GetAura(12292, EFFECT_INDEX_0);
+                    Aura* sweepingStrikeAura = GetAura(SweepingStrikeAuraID, EFFECT_INDEX_0);
                     SpellAuraHolder* sweepingStrike = sweepingStrikeAura->GetHolder();
                     int CurrentCharges = sweepingStrike->GetAuraCharges();
 
                     // Prevent chain of triggered spell from same triggered spell
-                    if (procSpell && procSpell->Id == 26654)
+                    if (procSpell && procSpell->Id == sweepingStrikeProcAA)
                         return SPELL_AURA_PROC_FAILED;
 
-                    if (procSpell && procSpell->Id == 12723)
+                    if (procSpell && procSpell->Id == SweepingStrikeProc)
                         return SPELL_AURA_PROC_FAILED;
 
                     target = SelectRandomUnfriendlyTarget(pVictim);
                     //Adjusting sweeping strike range to the same as whirlwind range incase the procSpell is WW (yes this is really necessary)
                     //in Spell.cpp under SPELLFAMILY_WARRIOR(Whirlwind) a simmilar adjustment is made which decides the range of where SS will remove a charge 
-                    if (procSpell && procSpell->Id == 1680)
+                    if (procSpell && procSpell->Id == WhirlWind)
                     {
                         target = SelectRandomUnfriendlyTarget(pVictim, 7.7);
                     }
 
+
                     //This adds a charge to SS, also 1 charge is withdrawn in the spell.cpp case if no target B is nearby but whirlwind or cleave hits a target A only.
-                    if ((!target && procSpell && procSpell->Id == 1680) || (!target && procSpell && procSpell->Id == 20569) || (!target && procSpell && procSpell->Id == 845) || (!target && procSpell && procSpell->Id == 7369) || (!target && procSpell && procSpell->Id == 11608) || (!target && procSpell && procSpell->Id == 11609))
+                    if (!target && procSpell && ((procSpell->Id == WhirlWind) || (procSpell->Id == CleaveRank5) || (procSpell->Id == CleaveRank1) || (procSpell->Id == CleaveRank2) || (procSpell->Id == CleaveRank3) || (procSpell->Id == CleaveRank4)))
 
                     {
                         sweepingStrike->SetAuraCharges(CurrentCharges + 1);
@@ -490,33 +505,33 @@ SpellAuraProcResult Unit::HandleDummyAuraProc(Unit *pVictim, uint32 damage, Aura
                         return SPELL_AURA_PROC_FAILED;
 
                     // Case for Execute. This will only run when procced by Execute
-                    if (procSpell && procSpell->Id == 20647)
+                    if (procSpell && procSpell->Id == Execute)
                     {
 
                         if (pVictim->GetHealthPercent() < 20.0f && target->GetHealthPercent() < 20.0f)  // If Both Target A and target B is sub 20% do full damage
                         {
                             basepoints[0] = damage * 100 / CalcArmorReducedDamage(pVictim, 100);
-                            triggered_spell_id = 12723; //Note this SS id deals 1 damage by itself (Cannot crit)
+                            triggered_spell_id = SweepingStrikeProc; //Note this SS id deals 1 damage by itself (Cannot crit)
 
                         }
                         else if (pVictim->GetHealthPercent() < 20.0f)	// If only Target A is sub 20% and target B is over 20% do Basic attack damage
                         {
-                            triggered_spell_id = 26654;	// This SS deals damage equal to AA also this spell ID can crit ?? Maybe this explains the rumor of SS criting since it only scales with spell crit ? = 5% crit.
+                            triggered_spell_id = sweepingStrikeProcAA;	// This SS deals damage equal to AA also this spell ID can crit ?? Maybe this explains the rumor of SS criting since it only scales with spell crit ? = 5% crit.
                         }
                         else // Full damage on anything else (Shouldn't really ever be used) since execute can only be used sub 20% anyway.                                             
                         {
                             basepoints[0] = damage * 100 / CalcArmorReducedDamage(pVictim, 100);
-                            triggered_spell_id = 12723;	//Note this SS id deals 1 damage by itself (Cannot crit)
+                            triggered_spell_id = SweepingStrikeProc;	//Note this SS id deals 1 damage by itself (Cannot crit)
                         }
                     }
 
                     // Case for Whirlwind and cleave. This will only run when procced by Whirlwind or cleave.
-                    else if ((procSpell && procSpell->Id == 1680) || (procSpell && procSpell->Id == 20569) || (procSpell && procSpell->Id == 845) || (procSpell && procSpell->Id == 7369) || (procSpell && procSpell->Id == 11608) || (procSpell && procSpell->Id == 11609))
+                    else if (procSpell && ((procSpell->Id == WhirlWind) || (procSpell->Id == CleaveRank1) || (procSpell->Id == CleaveRank2) || (procSpell->Id == CleaveRank3) || (procSpell->Id == CleaveRank4) || (procSpell->Id == CleaveRank5)))
 
                     {
 
                         basepoints[0] = damage * 100 / CalcArmorReducedDamage(pVictim, 100);
-                        triggered_spell_id = 12723;	//Note this SS id deals 1 damage by itself (Cannot crit)
+                        triggered_spell_id = SweepingStrikeProc;	//Note this SS id deals 1 damage by itself (Cannot crit)
 
                                                     //Adding a charge to the aura since when the case reaches "break;" a charge will be withdrawn.
                         sweepingStrike->SetAuraCharges(CurrentCharges + 1);
@@ -524,19 +539,14 @@ SpellAuraProcResult Unit::HandleDummyAuraProc(Unit *pVictim, uint32 damage, Aura
                         //Remove aura when charges reaches 0
                         if (CurrentCharges == 0)
                         {
-                            RemoveAura(12292, EFFECT_INDEX_0);
+                            RemoveAura(SweepingStrikeAuraID, EFFECT_INDEX_0);
                         }
 
-                    }
-                    else if (GetAura(20230, EFFECT_INDEX_0))
-                    {
-                        basepoints[0] = damage * 100 / CalcArmorReducedDamage(pVictim, 100);
-                        triggered_spell_id = 12723;	//Note this SS id deals 1 damage by itself (Cannot crit)
                     }
                     else // Full damage on anything else 
                     {
                         basepoints[0] = damage * 100 / CalcArmorReducedDamage(pVictim, 100);
-                        triggered_spell_id = 12723;	//Note this SS id deals 1 damage by itself (Cannot crit)
+                        triggered_spell_id = SweepingStrikeProc;	//Note this SS id deals 1 damage by itself (Cannot crit)
                     }
 
                     break;
@@ -545,6 +555,9 @@ SpellAuraProcResult Unit::HandleDummyAuraProc(Unit *pVictim, uint32 damage, Aura
                 // Retaliation
                 case 20230:
                 {
+                    int SweepingStrikeAuraID = 12292;
+                    int SweepingStrikeProcAA = 26654;
+                    int RetaliationProc = 22858;
                     // check attack comes not from behind
                     if (!HasInArc(M_PI_F, pVictim))
                     {
@@ -555,7 +568,7 @@ SpellAuraProcResult Unit::HandleDummyAuraProc(Unit *pVictim, uint32 damage, Aura
 
                     //Get random target and check if sweeping strike aura is on and a random target is available
             
-                    if (GetAura(12292, EFFECT_INDEX_0) && (target))
+                    if (GetAura(SweepingStrikeAuraID, EFFECT_INDEX_0) && (target))
                     {
                         target = SelectRandomUnfriendlyTarget(pVictim);
                         if (target)
@@ -563,30 +576,32 @@ SpellAuraProcResult Unit::HandleDummyAuraProc(Unit *pVictim, uint32 damage, Aura
                 
                     
                             //Get aura for modification of charges
-                            Aura* sweepingStrikeAura = GetAura(12292, EFFECT_INDEX_0);
+                            Aura* sweepingStrikeAura = GetAura(SweepingStrikeAuraID, EFFECT_INDEX_0);
                             SpellAuraHolder* sweepingStrike = sweepingStrikeAura->GetHolder();
                             int CurrentCharges = sweepingStrike->GetAuraCharges();
 
                             //Cast sweeping strike proc, the reason CastSpell is used because only one "triggered_spell_id" can be used in each case
                             //Otherwise the last "Triggered_spell_ID" in the case will be used before the break.
-                            CastSpell(pVictim, 26654, true, castItem, triggeredByAura);
+                            CastSpell(pVictim, SweepingStrikeProcAA, true, castItem, triggeredByAura);
 
                             //Remove aura if at 0
                             if (CurrentCharges == 0)
                             {
-                                RemoveAura(12292, EFFECT_INDEX_0);
+                                RemoveAura(SweepingStrikeAuraID, EFFECT_INDEX_0);
                             }
                             sweepingStrike->SetAuraCharges(CurrentCharges - 1);
                         }
                         else
                         {
                             target = pVictim;
-                            triggered_spell_id = 22858;
+                            triggered_spell_id = RetaliationProc;
                         }
                         //Removes a charge from sweeping strike aura
 
                     }
-                    triggered_spell_id = 22858;
+                    triggered_spell_id = RetaliationProc;
+            
+
                     break;
                 }
                 // Twisted Reflection (boss spell)

--- a/src/game/UnitAuraProcHandler.cpp
+++ b/src/game/UnitAuraProcHandler.cpp
@@ -469,7 +469,7 @@ SpellAuraProcResult Unit::HandleDummyAuraProc(Unit *pVictim, uint32 damage, Aura
                     Please note that UnitAuraProcHandler is not made to handle interactions like sweeping strike + Whirlwind/Cleave at all
                     reason being that UnitAuraProcHandler process the case for each hit and not per ability which results in a charge dropped per hit.
                     Instead modification to Spell.cpp has been made for whirlwind (SPELLFAMILY_WARRIOR) and cleave which handles the charge withdrawlas.
-                    1 Charge is always withdrawn everytime you use whirlwind or charge from spell.cpp which is why you will see +1 add charges in the prochandler here.
+                    1 Charge is always withdrawn everytime you use whirlwind or cleave from spell.cpp which is why you will see +1 add charges in the prochandler here.
                     */
 
                     // Spells

--- a/src/game/UnitAuraProcHandler.cpp
+++ b/src/game/UnitAuraProcHandler.cpp
@@ -444,7 +444,7 @@ SpellAuraProcResult Unit::HandleDummyAuraProc(Unit *pVictim, uint32 damage, Aura
                     triggered_spell_id = 25997;
                     break;
                 }
-	   // Sweeping Strikes
+	// Sweeping Strikes
 		case 12292:
 		case 18765:
 		{
@@ -476,7 +476,8 @@ SpellAuraProcResult Unit::HandleDummyAuraProc(Unit *pVictim, uint32 damage, Aura
 			}
 
 			//This adds a charge to SS, also 1 charge is withdrawn in the spell.cpp case if no target B is nearby but whirlwind or cleave hits a target A only.
-			if ((!target && procSpell && procSpell->Id == 1680) || (!target && procSpell && procSpell->Id == 20569))
+			if ((!target && procSpell && procSpell->Id == 1680) || (!target && procSpell && procSpell->Id == 20569) || (!target && procSpell && procSpell->Id == 845) || (!target && procSpell && procSpell->Id == 7369) || (!target && procSpell && procSpell->Id == 11608) || (!target && procSpell && procSpell->Id == 11609))
+
 			{
 				sweepingStrikeHolder->SetAuraCharges(CurrentCharges + 1);
 				return SPELL_AURA_PROC_FAILED;
@@ -511,14 +512,14 @@ SpellAuraProcResult Unit::HandleDummyAuraProc(Unit *pVictim, uint32 damage, Aura
 			}
 
 			// Case for Whirlwind and cleave. This will only run when procced by Whirlwind or cleave.
-			else if ((procSpell && procSpell->Id == 1680) || (procSpell && procSpell->Id == 20569))
-			{
+			else if ((procSpell && procSpell->Id == 1680) || (procSpell && procSpell->Id == 20569) || (procSpell && procSpell->Id == 845) || (procSpell && procSpell->Id == 7369) || (procSpell && procSpell->Id == 11608) || (procSpell && procSpell->Id == 11609))
 
+			{
 
 				basepoints[0] = damage * 100 / CalcArmorReducedDamage(pVictim, 100);
 				triggered_spell_id = 12723;	//Note this SS id deals 1 damage by itself (Cannot crit)
 
-				//Adding a charge to the aura since when the case reaches "break;" a charge will be withdrawn.
+											//Adding a charge to the aura since when the case reaches "break;" a charge will be withdrawn.
 				sweepingStrikeHolder->SetAuraCharges(CurrentCharges + 1);
 
 				//Remove aura when charges reaches 0
@@ -529,10 +530,10 @@ SpellAuraProcResult Unit::HandleDummyAuraProc(Unit *pVictim, uint32 damage, Aura
 
 			}
 			else if (GetAura(20230, EFFECT_INDEX_0))
-				{ 
+			{
 				basepoints[0] = damage * 100 / CalcArmorReducedDamage(pVictim, 100);
 				triggered_spell_id = 12723;	//Note this SS id deals 1 damage by itself (Cannot crit)
-				}
+			}
 			else // Full damage on anything else 
 			{
 				basepoints[0] = damage * 100 / CalcArmorReducedDamage(pVictim, 100);
@@ -547,37 +548,47 @@ SpellAuraProcResult Unit::HandleDummyAuraProc(Unit *pVictim, uint32 damage, Aura
 		{
 			// check attack comes not from behind
 			if (!HasInArc(M_PI_F, pVictim))
-			{	
+			{
 				return SPELL_AURA_PROC_FAILED;
 			}
-			else 
+
+
+
+			//Get random target and check if sweeping strike aura is on and a random target is available
+			
+			if (GetAura(12292, EFFECT_INDEX_0) && (target))
 			{
-				triggered_spell_id = 22858;
-			}
-
-			//Get random target and check if sweeping strike aura is on and a pVictim is available
-			target = SelectRandomUnfriendlyTarget(pVictim);
-			if (GetAura(12292, EFFECT_INDEX_0) && (pVictim))
-			{
-				//Get aura for modification of charges
-				Aura* sweepingStrikeAura = GetAura(12292, EFFECT_INDEX_0);
-				SpellAuraHolder* sweepingStrikeHolder = sweepingStrikeAura->GetHolder();
-				int CurrentCharges = sweepingStrikeHolder->GetAuraCharges();
-
-				//Cast sweeping strike proc, the reason CastSpell is used because only one "triggered_spell_id" can be used in each case
-				//Otherwise the last "Triggered_spell_ID" in the case will be used before the break.
-				CastSpell(pVictim, 26654, true, castItem, triggeredByAura);
-
-				//Remove aura if at 0
-				if (CurrentCharges == 0)
+				target = SelectRandomUnfriendlyTarget(pVictim);
+				if (target)
 				{
-					RemoveAura(12292, EFFECT_INDEX_0);
-				}
+				
+					
+					//Get aura for modification of charges
+					Aura* sweepingStrikeAura = GetAura(12292, EFFECT_INDEX_0);
+					SpellAuraHolder* sweepingStrikeHolder = sweepingStrikeAura->GetHolder();
+					int CurrentCharges = sweepingStrikeHolder->GetAuraCharges();
 
+					//Cast sweeping strike proc, the reason CastSpell is used because only one "triggered_spell_id" can be used in each case
+					//Otherwise the last "Triggered_spell_ID" in the case will be used before the break.
+					CastSpell(pVictim, 26654, true, castItem, triggeredByAura);
+
+					//Remove aura if at 0
+					if (CurrentCharges == 0)
+					{
+						RemoveAura(12292, EFFECT_INDEX_0);
+					}
+					sweepingStrikeHolder->SetAuraCharges(CurrentCharges - 1);
+				}
+				else
+				{
+					target = pVictim;
+					triggered_spell_id = 22858;
+				}
 				//Removes a charge from sweeping strike aura
-				sweepingStrikeHolder->SetAuraCharges(CurrentCharges - 1);
 
 			}
+			triggered_spell_id = 22858;
+			
 
 			break;
 		}

--- a/src/game/UnitAuraProcHandler.cpp
+++ b/src/game/UnitAuraProcHandler.cpp
@@ -570,6 +570,7 @@ SpellAuraProcResult Unit::HandleDummyAuraProc(Unit *pVictim, uint32 damage, Aura
             
                     if (GetAura(SweepingStrikeAuraID, EFFECT_INDEX_0) && (target))
                     {
+			//Checks if a random target is nearby.
                         target = SelectRandomUnfriendlyTarget(pVictim);
                         if (target)
                         {
@@ -593,6 +594,7 @@ SpellAuraProcResult Unit::HandleDummyAuraProc(Unit *pVictim, uint32 damage, Aura
                         }
                         else
                         {
+			    //If a random target is not nearby proc retaliation.
                             target = pVictim;
                             triggered_spell_id = RetaliationProc;
                         }

--- a/src/game/UnitAuraProcHandler.cpp
+++ b/src/game/UnitAuraProcHandler.cpp
@@ -444,154 +444,151 @@ SpellAuraProcResult Unit::HandleDummyAuraProc(Unit *pVictim, uint32 damage, Aura
                     triggered_spell_id = 25997;
                     break;
                 }
-	// Sweeping Strikes
 		case 12292:
-		case 18765:
-		{
-			/*
-			Please note that UnitAuraProcHandler is not made to handle interactions like sweeping strike + Whirlwind/Cleave at all
-			reason being that UnitAuraProcHandler process the case for each hit and not per ability which results in a charge dropped per hit.
-			Instead modification to Spell.cpp has been made for whirlwind (SPELLFAMILY_WARRIOR) and cleave which handles the charge withdrawlas.
-			1 Charge is always withdrawn everytime you use whirlwind from spell.cpp which is why you will see +1 add charges in the prochandler here.
-			*/
+                case 18765:
+                {
+                    /*
+                    Please note that UnitAuraProcHandler is not made to handle interactions like sweeping strike + Whirlwind/Cleave at all
+                    reason being that UnitAuraProcHandler process the case for each hit and not per ability which results in a charge dropped per hit.
+                    Instead modification to Spell.cpp has been made for whirlwind (SPELLFAMILY_WARRIOR) and cleave which handles the charge withdrawlas.
+                    1 Charge is always withdrawn everytime you use whirlwind or charge from spell.cpp which is why you will see +1 add charges in the prochandler here.
+                    */
 
-			//Fetch sweeping strike aura for being able to get and modify the amount the charges.
-			Aura* sweepingStrikeAura = GetAura(12292, EFFECT_INDEX_0);
-			SpellAuraHolder* sweepingStrikeHolder = sweepingStrikeAura->GetHolder();
-			int CurrentCharges = sweepingStrikeHolder->GetAuraCharges();
+                    //Fetch sweeping strike aura for being able to get and modify the amount the charges.
+                    Aura* sweepingStrikeAura = GetAura(12292, EFFECT_INDEX_0);
+                    SpellAuraHolder* sweepingStrike = sweepingStrikeAura->GetHolder();
+                    int CurrentCharges = sweepingStrike->GetAuraCharges();
 
-			// Prevent chain of triggered spell from same triggered spell
-			if (procSpell && procSpell->Id == 26654)
-				return SPELL_AURA_PROC_FAILED;
+                    // Prevent chain of triggered spell from same triggered spell
+                    if (procSpell && procSpell->Id == 26654)
+                        return SPELL_AURA_PROC_FAILED;
 
-			if (procSpell && procSpell->Id == 12723)
-				return SPELL_AURA_PROC_FAILED;
+                    if (procSpell && procSpell->Id == 12723)
+                        return SPELL_AURA_PROC_FAILED;
 
-			target = SelectRandomUnfriendlyTarget(pVictim);
-			//Adjusting sweeping strike range to the same as whirlwind range incase the procSpell is WW (yes this is really necessary)
-			//in Spell.cpp under SPELLFAMILY_WARRIOR(Whirlwind) a simmilar adjustment is made which decides the range of where SS will remove a charge 
-			if (procSpell && procSpell->Id == 1680)
-			{
-				target = SelectRandomUnfriendlyTarget(pVictim, 7.7);
-			}
+                    target = SelectRandomUnfriendlyTarget(pVictim);
+                    //Adjusting sweeping strike range to the same as whirlwind range incase the procSpell is WW (yes this is really necessary)
+                    //in Spell.cpp under SPELLFAMILY_WARRIOR(Whirlwind) a simmilar adjustment is made which decides the range of where SS will remove a charge 
+                    if (procSpell && procSpell->Id == 1680)
+                    {
+                        target = SelectRandomUnfriendlyTarget(pVictim, 7.7);
+                    }
 
-			//This adds a charge to SS, also 1 charge is withdrawn in the spell.cpp case if no target B is nearby but whirlwind or cleave hits a target A only.
-			if ((!target && procSpell && procSpell->Id == 1680) || (!target && procSpell && procSpell->Id == 20569) || (!target && procSpell && procSpell->Id == 845) || (!target && procSpell && procSpell->Id == 7369) || (!target && procSpell && procSpell->Id == 11608) || (!target && procSpell && procSpell->Id == 11609))
+                    //This adds a charge to SS, also 1 charge is withdrawn in the spell.cpp case if no target B is nearby but whirlwind or cleave hits a target A only.
+                    if ((!target && procSpell && procSpell->Id == 1680) || (!target && procSpell && procSpell->Id == 20569) || (!target && procSpell && procSpell->Id == 845) || (!target && procSpell && procSpell->Id == 7369) || (!target && procSpell && procSpell->Id == 11608) || (!target && procSpell && procSpell->Id == 11609))
 
-			{
-				sweepingStrikeHolder->SetAuraCharges(CurrentCharges + 1);
-				return SPELL_AURA_PROC_FAILED;
-			}
-			else if (!pVictim)
-			{
-				sweepingStrikeHolder->SetAuraCharges(CurrentCharges + 1);
-				return SPELL_AURA_PROC_FAILED;
-			}
-			else if (!target)
-				return SPELL_AURA_PROC_FAILED;
+                    {
+                        sweepingStrike->SetAuraCharges(CurrentCharges + 1);
+                        return SPELL_AURA_PROC_FAILED;
+                    }
+                    else if (!pVictim)
+                    {
+                        sweepingStrike->SetAuraCharges(CurrentCharges + 1);
+                        return SPELL_AURA_PROC_FAILED;
+                    }
+                    else if (!target)
+                        return SPELL_AURA_PROC_FAILED;
 
-			// Case for Execute. This will only run when procced by Execute
-			if (procSpell && procSpell->Id == 20647)
-			{
+                    // Case for Execute. This will only run when procced by Execute
+                    if (procSpell && procSpell->Id == 20647)
+                    {
 
-				if (pVictim->GetHealthPercent() < 20.0f && target->GetHealthPercent() < 20.0f)  // If Both Target A and target B is sub 20% do full damage
-				{
-					basepoints[0] = damage * 100 / CalcArmorReducedDamage(pVictim, 100);
-					triggered_spell_id = 12723; //Note this SS id deals 1 damage by itself (Cannot crit)
+                        if (pVictim->GetHealthPercent() < 20.0f && target->GetHealthPercent() < 20.0f)  // If Both Target A and target B is sub 20% do full damage
+                        {
+                            basepoints[0] = damage * 100 / CalcArmorReducedDamage(pVictim, 100);
+                            triggered_spell_id = 12723; //Note this SS id deals 1 damage by itself (Cannot crit)
 
-				}
-				else if (pVictim->GetHealthPercent() < 20.0f)	// If only Target A is sub 20% and target B is over 20% do Basic attack damage
-				{
-					triggered_spell_id = 26654;	// This SS deals damage equal to AA also this spell ID can crit ?? Maybe this explains the rumor of SS criting since it only scales with spell crit ? = 5% crit.
-				}
-				else // Full damage on anything else (Shouldn't really ever be used) since execute can only be used sub 20% anyway.                                             
-				{
-					basepoints[0] = damage * 100 / CalcArmorReducedDamage(pVictim, 100);
-					triggered_spell_id = 12723;	//Note this SS id deals 1 damage by itself (Cannot crit)
-				}
-			}
+                        }
+                        else if (pVictim->GetHealthPercent() < 20.0f)	// If only Target A is sub 20% and target B is over 20% do Basic attack damage
+                        {
+                            triggered_spell_id = 26654;	// This SS deals damage equal to AA also this spell ID can crit ?? Maybe this explains the rumor of SS criting since it only scales with spell crit ? = 5% crit.
+                        }
+                        else // Full damage on anything else (Shouldn't really ever be used) since execute can only be used sub 20% anyway.                                             
+                        {
+                            basepoints[0] = damage * 100 / CalcArmorReducedDamage(pVictim, 100);
+                            triggered_spell_id = 12723;	//Note this SS id deals 1 damage by itself (Cannot crit)
+                        }
+                    }
 
-			// Case for Whirlwind and cleave. This will only run when procced by Whirlwind or cleave.
-			else if ((procSpell && procSpell->Id == 1680) || (procSpell && procSpell->Id == 20569) || (procSpell && procSpell->Id == 845) || (procSpell && procSpell->Id == 7369) || (procSpell && procSpell->Id == 11608) || (procSpell && procSpell->Id == 11609))
+                    // Case for Whirlwind and cleave. This will only run when procced by Whirlwind or cleave.
+                    else if ((procSpell && procSpell->Id == 1680) || (procSpell && procSpell->Id == 20569) || (procSpell && procSpell->Id == 845) || (procSpell && procSpell->Id == 7369) || (procSpell && procSpell->Id == 11608) || (procSpell && procSpell->Id == 11609))
 
-			{
+                    {
 
-				basepoints[0] = damage * 100 / CalcArmorReducedDamage(pVictim, 100);
-				triggered_spell_id = 12723;	//Note this SS id deals 1 damage by itself (Cannot crit)
+                        basepoints[0] = damage * 100 / CalcArmorReducedDamage(pVictim, 100);
+                        triggered_spell_id = 12723;	//Note this SS id deals 1 damage by itself (Cannot crit)
 
-											//Adding a charge to the aura since when the case reaches "break;" a charge will be withdrawn.
-				sweepingStrikeHolder->SetAuraCharges(CurrentCharges + 1);
+                                                    //Adding a charge to the aura since when the case reaches "break;" a charge will be withdrawn.
+                        sweepingStrike->SetAuraCharges(CurrentCharges + 1);
 
-				//Remove aura when charges reaches 0
-				if (CurrentCharges == 0)
-				{
-					RemoveAura(12292, EFFECT_INDEX_0);
-				}
+                        //Remove aura when charges reaches 0
+                        if (CurrentCharges == 0)
+                        {
+                            RemoveAura(12292, EFFECT_INDEX_0);
+                        }
 
-			}
-			else if (GetAura(20230, EFFECT_INDEX_0))
-			{
-				basepoints[0] = damage * 100 / CalcArmorReducedDamage(pVictim, 100);
-				triggered_spell_id = 12723;	//Note this SS id deals 1 damage by itself (Cannot crit)
-			}
-			else // Full damage on anything else 
-			{
-				basepoints[0] = damage * 100 / CalcArmorReducedDamage(pVictim, 100);
-				triggered_spell_id = 12723;	//Note this SS id deals 1 damage by itself (Cannot crit)
-			}
+                    }
+                    else if (GetAura(20230, EFFECT_INDEX_0))
+                    {
+                        basepoints[0] = damage * 100 / CalcArmorReducedDamage(pVictim, 100);
+                        triggered_spell_id = 12723;	//Note this SS id deals 1 damage by itself (Cannot crit)
+                    }
+                    else // Full damage on anything else 
+                    {
+                        basepoints[0] = damage * 100 / CalcArmorReducedDamage(pVictim, 100);
+                        triggered_spell_id = 12723;	//Note this SS id deals 1 damage by itself (Cannot crit)
+                    }
 
-			break;
-		}
+                    break;
+                }
 
-		// Retaliation
-		case 20230:
-		{
-			// check attack comes not from behind
-			if (!HasInArc(M_PI_F, pVictim))
-			{
-				return SPELL_AURA_PROC_FAILED;
-			}
+                // Retaliation
+                case 20230:
+                {
+                    // check attack comes not from behind
+                    if (!HasInArc(M_PI_F, pVictim))
+                    {
+                        return SPELL_AURA_PROC_FAILED;
+                    }
 
 
 
-			//Get random target and check if sweeping strike aura is on and a random target is available
-			
-			if (GetAura(12292, EFFECT_INDEX_0) && (target))
-			{
-				target = SelectRandomUnfriendlyTarget(pVictim);
-				if (target)
-				{
-				
-					
-					//Get aura for modification of charges
-					Aura* sweepingStrikeAura = GetAura(12292, EFFECT_INDEX_0);
-					SpellAuraHolder* sweepingStrikeHolder = sweepingStrikeAura->GetHolder();
-					int CurrentCharges = sweepingStrikeHolder->GetAuraCharges();
+                    //Get random target and check if sweeping strike aura is on and a random target is available
+            
+                    if (GetAura(12292, EFFECT_INDEX_0) && (target))
+                    {
+                        target = SelectRandomUnfriendlyTarget(pVictim);
+                        if (target)
+                        {
+                
+                    
+                            //Get aura for modification of charges
+                            Aura* sweepingStrikeAura = GetAura(12292, EFFECT_INDEX_0);
+                            SpellAuraHolder* sweepingStrike = sweepingStrikeAura->GetHolder();
+                            int CurrentCharges = sweepingStrike->GetAuraCharges();
 
-					//Cast sweeping strike proc, the reason CastSpell is used because only one "triggered_spell_id" can be used in each case
-					//Otherwise the last "Triggered_spell_ID" in the case will be used before the break.
-					CastSpell(pVictim, 26654, true, castItem, triggeredByAura);
+                            //Cast sweeping strike proc, the reason CastSpell is used because only one "triggered_spell_id" can be used in each case
+                            //Otherwise the last "Triggered_spell_ID" in the case will be used before the break.
+                            CastSpell(pVictim, 26654, true, castItem, triggeredByAura);
 
-					//Remove aura if at 0
-					if (CurrentCharges == 0)
-					{
-						RemoveAura(12292, EFFECT_INDEX_0);
-					}
-					//Removes a charge from sweeping strike aura
-					sweepingStrikeHolder->SetAuraCharges(CurrentCharges - 1);
-				}
-				else
-				{
-					target = pVictim;
-					triggered_spell_id = 22858;
-				}
+                            //Remove aura if at 0
+                            if (CurrentCharges == 0)
+                            {
+                                RemoveAura(12292, EFFECT_INDEX_0);
+                            }
+                            sweepingStrike->SetAuraCharges(CurrentCharges - 1);
+                        }
+                        else
+                        {
+                            target = pVictim;
+                            triggered_spell_id = 22858;
+                        }
+                        //Removes a charge from sweeping strike aura
 
-			}
-			triggered_spell_id = 22858;
-			
-
-			break;
-		}
+                    }
+                    triggered_spell_id = 22858;
+                    break;
+                }
                 // Twisted Reflection (boss spell)
                 case 21063:
                     triggered_spell_id = 21064;

--- a/src/game/UnitAuraProcHandler.cpp
+++ b/src/game/UnitAuraProcHandler.cpp
@@ -577,6 +577,7 @@ SpellAuraProcResult Unit::HandleDummyAuraProc(Unit *pVictim, uint32 damage, Aura
 					{
 						RemoveAura(12292, EFFECT_INDEX_0);
 					}
+					//Removes a charge from sweeping strike aura
 					sweepingStrikeHolder->SetAuraCharges(CurrentCharges - 1);
 				}
 				else
@@ -584,7 +585,6 @@ SpellAuraProcResult Unit::HandleDummyAuraProc(Unit *pVictim, uint32 damage, Aura
 					target = pVictim;
 					triggered_spell_id = 22858;
 				}
-				//Removes a charge from sweeping strike aura
 
 			}
 			triggered_spell_id = 22858;

--- a/src/game/UnitAuraProcHandler.cpp
+++ b/src/game/UnitAuraProcHandler.cpp
@@ -566,7 +566,7 @@ SpellAuraProcResult Unit::HandleDummyAuraProc(Unit *pVictim, uint32 damage, Aura
 
 
 
-                    //Get random target and check if sweeping strike aura is on and a random target is available
+                    //Get random target and check if sweeping strike aura is on and a target is available
             
                     if (GetAura(SweepingStrikeAuraID, EFFECT_INDEX_0) && (target))
                     {

--- a/src/game/UnitAuraProcHandler.cpp
+++ b/src/game/UnitAuraProcHandler.cpp
@@ -490,7 +490,7 @@ SpellAuraProcResult Unit::HandleDummyAuraProc(Unit *pVictim, uint32 damage, Aura
 
 
                     //This adds a charge to SS, also 1 charge is withdrawn in the spell.cpp case if no target B is nearby but whirlwind or cleave hits a target A only.
-                    if (!target && procSpell && ((procSpell->Id == WhirlWind) || (procSpell->Id == CleaveRank5) || (procSpell->Id == CleaveRank1) || (procSpell->Id == CleaveRank2) || (procSpell->Id == CleaveRank3) || (procSpell->Id == CleaveRank4)))
+                    if (!target && procSpell && ((procSpell->Id == WhirlWind) || (procSpell->Id == CleaveRank1) || (procSpell->Id == CleaveRank2) || (procSpell->Id == CleaveRank3) || (procSpell->Id == CleaveRank4) || (procSpell->Id == CleaveRank5)))
 
                     {
                         sweepingStrike->SetAuraCharges(CurrentCharges + 1);


### PR DESCRIPTION
As i've written in the comments, it's a really complicated fix (Atleast in my eyes)
Reason being is the UnitAuraProcHandler isn't made to support Whirlwind or Cleave interaction with sweeping strikes in any way.

This gives a minor bug i really can't wrap my head about how to fix with whirlwind and cleave.
If there is only 1 charge left and you proc sweeping strikes with whirlwind or cleave only one target will be hit by the sweeping strike proc (Which would also happen on live)


Fixed so that Whirlwind taking only one charge.
Fixed so that Cleave taking only one charge.
Fixed Whirlwind not consuming a charge if it's too close to another NPC without hitting it.
Fixed Retaliation to work with sweeping strikes.
Fixed sweeping strikes procs getting double bonus from percentage damage increase. Tested with enrage and death wish (AUCH!)
Adjusted whirlwind range to the same as sweeping strikes.

I'd like some feedback on the variable naming, commenting and code that should be added if something should be what nullified ?? remove variables ?? (whatever these terms is called) since c++ is my first object oriented programming language (i've only worked with bash and powershell scripts).
