### PR TITLE
Spell coefficient overhaul

### DIFF
--- a/sql/migrations/20170420135725_world.sql
+++ b/sql/migrations/20170420135725_world.sql
@@ -1,0 +1,93 @@
+INSERT INTO `migrations` VALUES ('20170420135725');
+
+-- DRUID --
+
+-- Entangling Roots: (1.5/3.5 * 0.95) / 9
+UPDATE spell_bonus_data SET dot_bonus=0.04524 WHERE entry=339;
+
+-- Hurricane: (3.5/3.5*0.95/3) / 10
+UPDATE spell_bonus_data SET dot_bonus=0.03166 WHERE entry=16914;
+
+-- Insect Swarm: (12/15/0.95) / 6
+UPDATE spell_bonus_data SET dot_bonus=0.14035 WHERE entry=5570;
+
+-- Regrowth DoT: ((15/15)(15/15) / (2/3.5 + 15/15)) / 7
+UPDATE spell_bonus_data SET dot_bonus=0.09091 WHERE entry=8936;
+
+-- Tranquility: (3.5/3.5/3) / 5
+UPDATE spell_bonus_data SET dot_bonus=0.06666 WHERE entry=8936;
+
+-- Healing Touch: Variable cast time - handled by code
+DELETE FROM spell_bonus_data WHERE entry=5185;
+
+-- Wrath: Variable cast time - handled by code
+DELETE FROM spell_bonus_data WHERE entry=5176;
+
+
+-- MAGE --
+
+-- Arcane Missiles: (3.5/3.5) / 5
+UPDATE spell_bonus_data SET direct_bonus=0.2 WHERE entry=7269;
+
+-- Blast Wave: 1.5/3.5/3*0.95
+UPDATE spell_bonus_data SET direct_bonus=0.13571 WHERE entry=11113;
+
+-- Cone of Cold: 1.5/3.5/3*0.95
+UPDATE spell_bonus_data SET direct_bonus=0.13571 WHERE entry=120;
+
+-- Frostbolt: Variable cast time - handled by code
+DELETE FROM spell_bonus_data WHERE entry=116;
+
+-- Flamestrike Direct: (3/3.5)(3/3.5) / (3/3.5 + 8/15) / 3
+UPDATE spell_bonus_data SET direct_bonus=0.17612 WHERE entry=2120;
+
+-- Flamestrike DoT: ((8/15)*(8/15) / (3/3.5 + 8/15) / 3) / 4
+UPDATE spell_bonus_data SET dot_bonus=0.01704 WHERE entry=2120;
+
+-- Mana Shield: Should have 0 coefficient
+DELETE FROM spell_bonus_data WHERE entry=1463;
+
+-- Pyroblast DoT: 0.7 / 4
+UPDATE spell_bonus_data SET dot_bonus=0.175 WHERE entry=11366;
+
+
+-- PRIEST --
+
+-- Holy Nova: 1.5/3.5/3*0.8
+UPDATE spell_bonus_data SET direct_bonus=0.11428 WHERE entry IN (15237,27779,23455,23458,23459,27803,27804,27805);
+
+-- Mana Burn: Should have 0 coefficient
+UPDATE spell_bonus_data SET direct_bonus=0 WHERE entry=8129;
+
+
+-- SHAMAN --
+
+-- Healing Stream: 0.65 / 30
+UPDATE spell_bonus_data SET dot_bonus=0.02166 WHERE entry=5672;
+
+-- Healing Wave: Variable cast time - handled by code
+DELETE FROM spell_bonus_data WHERE entry=331;
+
+-- Lightning Bolt: Variable cast time - handled by code
+DELETE FROM spell_bonus_data WHERE entry=403;
+
+-- Magma Totem: (1 / 3) / 10
+UPDATE spell_bonus_data SET direct_bonus=0.03333 WHERE entry IN (8187,10579,10580,10581);
+
+-- Searing Totem: 0.08
+UPDATE spell_bonus_data SET direct_bonus=0.08 WHERE entry IN (3606,6350,6351,6352,10435,10436);
+
+
+-- WARLOCK --
+
+-- Hellfire: (3.5/3.5/3) / 15
+UPDATE spell_bonus_data SET dot_bonus=0.0222 WHERE entry=1949;
+
+-- Immolate Direct: (2/3.5)(2/3.5) / (2/3.5 + 15/15)
+UPDATE spell_bonus_data SET direct_bonus=0.20779 WHERE entry=348;
+
+-- Immolate DoT: ((15/15)(15/15) / (2/3.5 + 15/15)) / 5
+UPDATE spell_bonus_data SET dot_bonus=0.12727 WHERE entry=348;
+
+-- Shadow Bolt: Variable cast time - handled by code
+DELETE FROM spell_bonus_data WHERE entry=686;

--- a/src/game/Spells/SpellAuras.cpp
+++ b/src/game/Spells/SpellAuras.cpp
@@ -5525,11 +5525,11 @@ void Aura::HandleManaShield(bool apply, bool Real)
             float DoneActualBenefit = 0.0f;
 
             // Mana Shield
-            // +50% from +spd bonus
-            if (GetSpellProto()->IsFitToFamily<SPELLFAMILY_MAGE, CF_MAGE_MANA_SHIELD>())
-                DoneActualBenefit = caster->SpellBaseDamageBonusDone(GetSpellSchoolMask(GetSpellProto())) * 0.5f;
+            // 0% coeff in vanilla (changed patch 2.4.0)
+            // if (GetSpellProto()->IsFitToFamily<SPELLFAMILY_MAGE, CF_MAGE_MANA_SHIELD>())
+            //    DoneActualBenefit = caster->SpellBaseDamageBonusDone(GetSpellSchoolMask(GetSpellProto())) * 0.5f;
 
-            DoneActualBenefit *= caster->CalculateLevelPenalty(GetSpellProto());
+            // DoneActualBenefit *= caster->CalculateLevelPenalty(GetSpellProto());
 
             m_modifier.m_amount += (int32)DoneActualBenefit;
         }


### PR DESCRIPTION
Related issues: 
https://github.com/elysium-project/server/issues/436
https://www.reddit.com/r/ElysiumProject/comments/5ys0c1/cast_time_coefficient_on_downranked_spells_is/

I was looking at those issues and found that the level penalty mechanic was working correctly but the base coefficient of a bunch of spells were wrong, for various reasons: Some spells were just slightly innacurate, some were using TBC coefficients that were far higher than they should be and some had the last rank coefficient applied to every rank. 

I went through every entry in the _spell_bonus_data_ table and fixed these:

**Healing Touch**, **Wrath**, **Frostbolt**, **Lightning Bolt** and **Shadow Bolt** had the last rank coeff on every rank.

**Healing Wave** had the first rank coeff on every rank, high rank healing waves were healing for way less than what they should.

**Mana Shield** was getting benefits from spell damage when it should have 0% coefficient:
>TBC Patch 2.4.0 (2008-03-25): This spell will now get a percentage of the Mage’s bonus to spell power as an additional effect. (Note : That's 50% of your spell damage)
>http://wow.gamepedia.com/Mana_Shield_(original)

**Mana Burn** should have 0% coefficient as well, I found no evidence of it ever having a coefficient

Other spells and their new values:

**Entangling Roots** (1.5/3.5 * 0.95) / 9
**Hurricane** (3.5/3.5 * 0.95/3) / 10
**Insect Swarm** (12/15/0.95) / 6
**Regrowth DoT** ((15/15)(15/15) / (2/3.5 + 15/15)) / 7
**Tranquility** (3.5/3.5/3) / 5

**Arcane Missiles** (3.5/3.5) / 5
**Blast Wave** 1.5/3.5/3 * 0.95
**Cone of Cold** 1.5/3.5/3 * 0.95
**Flamestrike Direct** (3/3.5)(3/3.5) / (3/3.5 + 8/15) / 3
**Flamestrike DoT** ((8/15) * (8/15) / (3/3.5 + 8/15) / 3) / 4
**Pyroblast DoT** 0.7 / 4

**Holy Nova** 1.5/3.5/3*0.8

**Healing Stream** 0.65 / 30
**Magma Totem** (1 / 3) / 10
**Searing Totem** 0.08

**Hellfire** (3.5/3.5/3) / 15
**Immolate Direct** (2/3.5)(2/3.5) / (2/3.5 + 15/15)
**Immolate DoT** ((15/15)(15/15) / (2/3.5 + 15/15)) / 5

Some are just small adjustments, others are huge nerfs (Flamestrike DoT was getting 33% per tick instead of 1.7% wtf).

**Sources**
1.12 Theorycraft addon
http://wow.allakhazam.com/wiki/spell_coefficient_(wow)
https://forum.twinstar.cz/showthread.php/57011-Big-TheoryCrafting-Thread?p=498319&viewfull=1#post498319

(be aware some of the math in those sources is wrong, I redid all the math myself)
