### PR TITLE
Fix teleporting during move splines due to rooting effects and movesplines being incorrectly interrupted (possible DC fix)

### DIFF
--- a/src/game/Commands/Level3.cpp
+++ b/src/game/Commands/Level3.cpp
@@ -6443,6 +6443,7 @@ bool ChatHandler::HandleDebugMoveCommand(char* args)
     {
         case 0:
             target->GetMotionMaster()->Clear(true, true);
+            target->GetMotionMaster()->MoveIdle();
             break;
         case 1:
             target->GetMotionMaster()->MoveIdle();

--- a/src/game/Commands/Level3.cpp
+++ b/src/game/Commands/Level3.cpp
@@ -6442,18 +6442,21 @@ bool ChatHandler::HandleDebugMoveCommand(char* args)
     switch (movetype)
     {
         case 0:
-            target->GetMotionMaster()->MoveIdle();
+            target->GetMotionMaster()->Clear(true, true);
             break;
         case 1:
-            target->GetMotionMaster()->MoveRandom();
+            target->GetMotionMaster()->MoveIdle();
             break;
         case 2:
-            target->GetMotionMaster()->MoveConfused();
+            target->GetMotionMaster()->MoveRandom();
             break;
         case 3:
-            target->GetMotionMaster()->MoveFleeing(m_session->GetPlayer());
+            target->GetMotionMaster()->MoveConfused();
             break;
         case 4:
+            target->GetMotionMaster()->MoveFleeing(m_session->GetPlayer());
+            break;
+        case 5:
             target->GetMotionMaster()->MoveFeared(m_session->GetPlayer());
             break;
     }

--- a/src/game/Handlers/MovementHandler.cpp
+++ b/src/game/Handlers/MovementHandler.cpp
@@ -764,39 +764,12 @@ void WorldSession::HandleMoveUnRootAck(WorldPacket& recv_data)
     if (!_player->GetCheatData()->HandleAnticheatTests(movementInfo, this, &recv_data))
         return;
 
-    
-    // Position change
+    // Update position if it has changed (possible on UNROOT ack?)
     HandleMoverRelocation(movementInfo);
     _player->UpdateFallInformationIfNeed(movementInfo, recv_data.GetOpcode());
 
-    DEBUG_LOG("WorldSession::HandleMoveUnRootAck - client movement info x: %f, y: %f, z: %f",
-              movementInfo.GetPos()->x, movementInfo.GetPos()->y, movementInfo.GetPos()->z);
-    
-    DEBUG_LOG("WorldSession::HandleMoveUnRootAck - server movement info x: %f, y: %f, z: %f",
-              _player->m_movementInfo.GetPos()->x, _player->m_movementInfo.GetPos()->y, _player->m_movementInfo.GetPos()->z);
-    
-    /*Movement::MoveSpline* spline = _player->GetMover()->movespline;
-    DEBUG_LOG("WorldSession::HandleMoveUnRootAck - movespline curr info x: %f, y: %f, z: %f",
-              spline->GetPoint(spline->currentPathIdx())[0], spline->GetPoint(spline->currentPathIdx())[1], spline->GetPoint(spline->currentPathIdx())[2]);*/
-    
-    /*WorldPacket data(MSG_MOVE_UNROOT, recv_data.size());
-    data << _player->GetPackGUID();
-    // write player movement data, not the one sent by client
-    //_player->m_movementInfo.Write(data);
-    movementInfo.Write(data);
-    _player->SendMovementMessageToSet(std::move(data), false);
-    */
+    // Clear unit client state for brevity, though it should not be used
     _player->clearUnitState(UNIT_STAT_CLIENT_ROOT);
-    
-    // Resend spline data after unroot opcode & move info. Only send to
-    // set, client already knows about it
-    /*if (!_player->GetMover()->movespline->Finalized())
-    {
-        WorldPacket splineData(SMSG_MONSTER_MOVE, 64);
-        splineData << _player->GetMover()->GetPackGUID();
-        Movement::PacketBuilder::WriteMonsterMove(*(_player->GetMover()->movespline), splineData);
-        _player->SendMovementMessageToSet(std::move(splineData), false);
-    }*/
 }
 
 void WorldSession::HandleMoveRootAck(WorldPacket& recv_data)
@@ -825,22 +798,6 @@ void WorldSession::HandleMoveRootAck(WorldPacket& recv_data)
     // Position change
     HandleMoverRelocation(movementInfo);
     _player->UpdateFallInformationIfNeed(movementInfo, recv_data.GetOpcode());
-    
-    DEBUG_LOG("WorldSession::HandleMoveRootAck - client movement info x: %f, y: %f, z: %f",
-              movementInfo.GetPos()->x, movementInfo.GetPos()->y, movementInfo.GetPos()->z);
-    
-    DEBUG_LOG("WorldSession::HandleMoveRootAck - server movement info x: %f, y: %f, z: %f",
-              _player->m_movementInfo.GetPos()->x, _player->m_movementInfo.GetPos()->y, _player->m_movementInfo.GetPos()->z);
-    
-    Movement::MoveSpline* spline = _player->GetMover()->movespline;
-    if (!spline->Finalized())
-        DEBUG_LOG("WorldSession::HandleMoveRootAck - movespline curr info x: %f, y: %f, z: %f",
-              spline->GetPoint(spline->currentPathIdx())[0], spline->GetPoint(spline->currentPathIdx())[1], spline->GetPoint(spline->currentPathIdx())[2]);
-
-    WorldPacket data(MSG_MOVE_ROOT, recv_data.size());
-    data << _player->GetPackGUID();
-    movementInfo.Write(data);
-    _player->SendMovementMessageToSet(std::move(data), false);
     
     _player->addUnitState(UNIT_STAT_CLIENT_ROOT);
 }

--- a/src/game/Handlers/MovementHandler.cpp
+++ b/src/game/Handlers/MovementHandler.cpp
@@ -263,7 +263,6 @@ void WorldSession::HandleMovementOpcodes(WorldPacket & recv_data)
     DEBUG_LOG("WORLD: Recvd %s (%u, 0x%X) opcode", LookupOpcodeName(opcode), opcode, opcode);
 
     Unit *mover = _player->GetMover();
-    DEBUG_LOG("WorldSession::HandleMovementOpcodes - mover guid: %s", mover->GetGuidStr().c_str());
     if (mover->GetObjectGuid() != _clientMoverGuid)
         return;
         
@@ -799,6 +798,7 @@ void WorldSession::HandleMoveRootAck(WorldPacket& recv_data)
     HandleMoverRelocation(movementInfo);
     _player->UpdateFallInformationIfNeed(movementInfo, recv_data.GetOpcode());
     
+    // Set unit client state for brevity, though it should not be used
     _player->addUnitState(UNIT_STAT_CLIENT_ROOT);
 }
 

--- a/src/game/Handlers/MovementHandler.cpp
+++ b/src/game/Handlers/MovementHandler.cpp
@@ -404,7 +404,7 @@ void WorldSession::HandleForceSpeedChangeAckOpcodes(WorldPacket &recv_data)
     
     if (!_player->GetMover()->movespline->Finalized())
     {
-        WorldPacket splineData(SMSG_MONSTER_MOVE, 64);
+        WorldPacket splineData(SMSG_MONSTER_MOVE, 31);
         splineData << _player->GetMover()->GetPackGUID();
         Movement::PacketBuilder::WriteMonsterMove(*(_player->GetMover()->movespline), splineData);
         _player->SendMovementMessageToSet(std::move(splineData), false);

--- a/src/game/Movement/spline/MoveSplineInit.cpp
+++ b/src/game/Movement/spline/MoveSplineInit.cpp
@@ -164,7 +164,7 @@ int32 MoveSplineInit::Launch()
         compress = true;
     else if ((data.wpos() + 2) > 0x10)
         compress = true;
-    else if (unit.hasUnitState(UNIT_STAT_CLIENT_ROOT))
+    else if (oldMoveFlags & MOVEFLAG_ROOT)
         compress = true;
     // Since packet size is stored with an uint8, packet size is limited for compressed packets
     if ((data.wpos() + 2) > 0xFF)
@@ -180,7 +180,7 @@ int32 MoveSplineInit::Launch()
     // We need to fix this, in case of charges for example (if character has movement slowing effects)
     if (args.velocity > 4 * realSpeedRun && !args.flags.done) // From client
         mvtData.SetUnitSpeed(SMSG_SPLINE_SET_RUN_SPEED, unit.GetObjectGuid(), args.velocity);
-    if (unit.hasUnitState(UNIT_STAT_CLIENT_ROOT))
+    if (oldMoveFlags & MOVEFLAG_ROOT)
         mvtData.SetSplineOpcode(SMSG_SPLINE_MOVE_UNROOT, unit.GetObjectGuid());
     if (oldMoveFlags & MOVEFLAG_WALK_MODE && !(moveFlags & MOVEFLAG_WALK_MODE)) // Switch to run mode
         mvtData.SetSplineOpcode(SMSG_SPLINE_MOVE_SET_RUN_MODE, unit.GetObjectGuid());

--- a/src/game/Movement/spline/MoveSplineInit.cpp
+++ b/src/game/Movement/spline/MoveSplineInit.cpp
@@ -181,8 +181,6 @@ int32 MoveSplineInit::Launch()
     {
         WorldPacket data2;
         if (mvtData.BuildPacket(data2)) {
-            if (unit.IsPlayer())
-            DEBUG_LOG("MoveSplineInit::Launch - Sending compressed movement packet to members in cell");
             unit.SendMovementMessageToSet(std::move(data2), true);
         }
         else {

--- a/src/game/Objects/Unit.cpp
+++ b/src/game/Objects/Unit.cpp
@@ -11110,6 +11110,14 @@ void Unit::SetMovement(UnitMovementType pType)
     {
         mePlayer->GetCheatData()->OrderSent(&data);
         mePlayer->GetSession()->SendPacket(&data);
+        
+        if (pType == MOVE_ROOT || pType == MOVE_UNROOT) {
+            WorldPacket rootData(pType == MOVE_ROOT ? MSG_MOVE_ROOT : MSG_MOVE_UNROOT, 31);
+            rootData << GetPackGUID();
+            rootData << m_movementInfo;
+            
+            mePlayer->SendMovementMessageToSet(std::move(rootData), false);
+        }
     }
     if (controller)
         controller->GetSession()->SendPacket(&data);

--- a/src/game/Objects/Unit.cpp
+++ b/src/game/Objects/Unit.cpp
@@ -10844,9 +10844,8 @@ void Unit::UpdateSplineMovement(uint32 t_diff)
         return;
 
     movespline->updateState(t_diff);
-    
     bool arrived = movespline->Finalized();
-    
+
     if (arrived)
         DisableSpline();
     else if (!movespline->isCyclic() && movespline->getLastPointSent() >= 0 && movespline->getLastPointSent() < (movespline->currentPathIdx() + 3))


### PR DESCRIPTION
Since this is a fairly far reaching commit, I'm going to go into a bit of depth rather than a short note. The latest patch notes suggest that fear & stun DCs have been fixed, however many players are still experiencing the same issue. I've also noticed the same behaviour as before the patch - feared players teleport around if they are rooted by some effect, or if they are rooted and then feared. Since there were no core changes to coincide with the notes, I can only speculate the changes were made in the anti cheat. It is my belief that this teleportation is the cause of disconnects due to false positives in the AC.

I've been doing a fair bit of digging and testing over the past few days, making some changes with the behaviour of root flags and movesplines, and have been able to eliminate the behaviour causing players to be teleporting when applying splines to rooted targets, and when applying roots to targets under motion from a generator (spline). These changes also fix the issue where players under the motion of a spline can appear to stand still, and then suddenly teleport to the spline destination (ala Death Coil). The reason for other spells not experiencing this is because they apply a speed modifier, which is handled later in MovementHandler::HandleForceSpeedChangeAckOpcodes which resends the spline after the motion would have normally been broken, as documented in my commits. They still suffered from the root teleportation though.

Firstly, Unit::StopMoving was sending a movespline which caused the player to move on the spot (and set a facing direction - which is unnecessary or should be done differently) rather than only sending a spline with a stop code. This resulted in motions that were sent immediately after this (i.e. in MovementGenerators) being ignored since the client was processing the previous spline - observing the network packets confirms this, with MSG_MOVE_STOP and SPLINE_DONE being sent in response to the first spline, after the generator's spline is sent - meaning we'd need to resend it (which is what happens with some spells, allowing them to work). To fix this, we now only send a stop spline, and we only send it if the currently executing spline is not finalized. This was the cause of Death Coil making the unit stand still, and then teleport to the end destination.

In the case of ROOTs and splines, there were a number of issues. To begin, SMSG_SPLINE_MOVE_UNROOT was never being sent since UNIT_STAT_CLIENT_ROOT was being cleared far too early. This meant that new splines did not automatically clear roots, and we relied upon Unit::SetMovement to send clear root flags (which were only sent to the target). Furthermore, clients in the vicinity of the target relied on the client ack response before being sent a flag clearing the root - which meant players appeared stationary, and then teleported (sometimes boomeranging due to an outdated movement packet). 

Moreover, since UNIT_STAT_CLIENT_ROOT relied on an ACK response to be cleared and set, there was a significant delay between clients in the vicinity being told of the root removal and application in comparison to the spline being sent, so players would often sprint through the spline or teleport if the ack's movement data was outdated. This also resulted in some desync issues with root flags and splines. To rectify this, we no longer rely on client acks for setting and clearing root flags. Instead, we now send MSG_MOVE_ROOT and MSG_MOVE_UNROOT inside Unit::SetMovement when applying MOVEFLAG_ROOT to the unit's movement info, so it is updated immediately for everyone. Similarly, the spline now checks moveflags for MOVEFLAG_ROOT when deciding whether or not to send SMSG_SPLINE_MOVE_UNROOT. 

The MSG_MOVE_*ROOT packets are usually sent before a spline, but if they aren't the root flag will be synced and the spline will know about it, and be able to remove the root. Note that this does not mean splines will execute while players are rooted and allow them to move out of it - this is already handled in the existing implementation (MotionMaster doesn't update generators if the client is stunned, and generators check if movement is possible). This means the server is now in complete control of the unit's root state and we can keep it synced for all clients.

Hopefully this rectifies the disconnect issues, it will at least for certain fix players teleporting. To easily test, use auras 12809 (concussive blow - 5s stun) and fear (6125) on a character logged in on a second client. '.debug movemotion #' is also useful.

Related issues: 
#313 
https://elysium-project.org/bugtracker/issue/3734
https://elysium-project.org/bugtracker/issue/1758
https://elysium-project.org/bugtracker/issue/3873
and the other 500 reports on the same problem