### PR TITLE
Don't register unused scripts

### DIFF
--- a/src/scripts/ScriptLoader.cpp
+++ b/src/scripts/ScriptLoader.cpp
@@ -15,11 +15,11 @@ void AddSC_bg_alterac();
 //custom
 void AddSC_zero_scripts();
 void AddSC_ubrs_trash();
-void AddSC_gmisland();
+//void AddSC_gmisland();
 //void AddSC_boss_arena_hardog(); // EVENT de TORKIN
 
 // Event
-void AddSC_event_attack_city();
+//void AddSC_event_attack_city();
 void AddSC_elemental_invasions();
 
 // HT
@@ -63,7 +63,7 @@ void AddSC_instance_blackrock_depths();
 void AddSC_boss_drakkisath();                        //blackrock_spire
 void AddSC_boss_halycon();
 void AddSC_boss_highlordomokk();
-void AddSC_boss_mothersmolderweb();
+//void AddSC_boss_mothersmolderweb();
 void AddSC_boss_overlordwyrmthalak();
 void AddSC_boss_shadowvosh();
 void AddSC_boss_thebeast();
@@ -86,8 +86,8 @@ void AddSC_instance_blackwing_lair();
 void AddSC_deadmines();                              //deadmines
 void AddSC_instance_deadmines();
 void AddSC_boss_mr_smite();
-void AddSC_boss_sneed_shredder();
-void AddSC_boss_sneed();
+//void AddSC_boss_sneed_shredder();
+//void AddSC_boss_sneed();
 
 void AddSC_gnomeregan();                             //gnomeregan
 void AddSC_boss_thermaplugg();
@@ -120,7 +120,7 @@ void AddSC_boss_razuvious();
 void AddSC_boss_sapphiron();
 void AddSC_instance_naxxramas();
 void AddSC_boss_arcanist_doan();                     //scarlet_monastery
-void AddSC_boss_azshir_the_sleepless();
+//void AddSC_boss_azshir_the_sleepless();
 void AddSC_boss_bloodmage_thalnos();
 void AddSC_boss_scorn();
 void AddSC_boss_herod();
@@ -135,7 +135,7 @@ void AddSC_boss_theolenkrastinov();
 void AddSC_boss_illuciabarov();
 void AddSC_boss_instructormalicia();
 void AddSC_boss_jandicebarov();
-void AddSC_boss_kormok();
+//void AddSC_boss_kormok();
 void AddSC_boss_lordalexeibarov();
 void AddSC_boss_lorekeeperpolkelt();
 void AddSC_boss_rasfrost();
@@ -166,9 +166,9 @@ void AddSC_uldaman();                                //uldaman
 void AddSC_boss_archaedas();
 void AddSC_boss_arlokk();                            //zulgurub
 void AddSC_boss_gahzranka();
-void AddSC_boss_grilek();
+//void AddSC_boss_grilek();
 void AddSC_boss_hakkar();
-void AddSC_boss_hazzarah();
+//void AddSC_boss_hazzarah();
 void AddSC_boss_jeklik();
 void AddSC_boss_jindo();
 void AddSC_boss_mandokir();
@@ -177,7 +177,7 @@ void AddSC_boss_ouro();
 void AddSC_boss_renataki();
 void AddSC_boss_thekal();
 void AddSC_boss_venoxis();
-void AddSC_boss_wushoolay();
+//void AddSC_boss_wushoolay();
 void AddSC_instance_zulgurub();
 void AddSC_zg_trash();
 void AddSC_boss_omen();
@@ -227,7 +227,7 @@ void AddSC_boss_kurinnaxx();
 void AddSC_boss_moam();
 void AddSC_boss_ossirian();
 void AddSC_boss_rajaxx();
-void AddSC_npc_sandstalker(); 						// trash
+//void AddSC_npc_sandstalker(); 						// trash
 void AddSC_ruins_of_ahnqiraj();
 void AddSC_instance_ruins_of_ahnqiraj();
 void AddSC_boss_cthun();                             //temple_of_ahnqiraj
@@ -282,10 +282,10 @@ void AddScripts()
     //custom
     AddSC_zero_scripts();
     AddSC_ubrs_trash();
-    AddSC_gmisland();
+    //AddSC_gmisland();
 
     // Event
-    AddSC_event_attack_city();
+    //AddSC_event_attack_city();
     AddSC_elemental_invasions();
 
     // HT
@@ -328,7 +328,7 @@ void AddScripts()
     AddSC_boss_drakkisath();                                //blackrock_spire
     AddSC_boss_halycon();
     AddSC_boss_highlordomokk();
-    AddSC_boss_mothersmolderweb();
+    //AddSC_boss_mothersmolderweb();
     AddSC_boss_overlordwyrmthalak();
     AddSC_boss_shadowvosh();
     AddSC_boss_thebeast();
@@ -352,8 +352,8 @@ void AddScripts()
     AddSC_deadmines();                                      //deadmines
     AddSC_instance_deadmines();
     AddSC_boss_mr_smite();
-    AddSC_boss_sneed_shredder();
-    AddSC_boss_sneed();
+    //AddSC_boss_sneed_shredder();
+    //AddSC_boss_sneed();
     AddSC_gnomeregan();                                     //gnomeregan
     AddSC_boss_thermaplugg();
     AddSC_instance_gnomeregan();
@@ -384,7 +384,7 @@ void AddScripts()
     AddSC_boss_sapphiron();
     AddSC_instance_naxxramas();
     AddSC_boss_arcanist_doan();                             //scarlet_monastery
-    AddSC_boss_azshir_the_sleepless();
+    //AddSC_boss_azshir_the_sleepless();
     AddSC_boss_bloodmage_thalnos();
     AddSC_boss_scorn();
     AddSC_boss_herod();
@@ -399,7 +399,7 @@ void AddScripts()
     AddSC_boss_illuciabarov();
     AddSC_boss_instructormalicia();
     AddSC_boss_jandicebarov();
-    AddSC_boss_kormok();
+    //AddSC_boss_kormok();
     AddSC_boss_lordalexeibarov();
     AddSC_boss_lorekeeperpolkelt();
     AddSC_boss_rasfrost();
@@ -430,9 +430,9 @@ void AddScripts()
     AddSC_boss_archaedas();
     AddSC_boss_arlokk();                                    //zulgurub
     AddSC_boss_gahzranka();
-    AddSC_boss_grilek();
+    //AddSC_boss_grilek();
     AddSC_boss_hakkar();
-    AddSC_boss_hazzarah();
+    //AddSC_boss_hazzarah();
     AddSC_boss_jeklik();
     AddSC_boss_jindo();
     AddSC_boss_mandokir();
@@ -441,7 +441,7 @@ void AddScripts()
     AddSC_boss_renataki();
     AddSC_boss_thekal();
     AddSC_boss_venoxis();
-    AddSC_boss_wushoolay();
+    //AddSC_boss_wushoolay();
     AddSC_instance_zulgurub();
     AddSC_zg_trash();
     AddSC_boss_omen();
@@ -492,7 +492,7 @@ void AddScripts()
     AddSC_boss_ossirian();
     AddSC_boss_rajaxx();
     AddSC_ruins_of_ahnqiraj();
-	AddSC_npc_sandstalker();								//trash
+	//AddSC_npc_sandstalker();								//trash
     AddSC_instance_ruins_of_ahnqiraj();
     AddSC_boss_cthun();                                     //temple_of_ahnqiraj
 	AddSC_boss_viscidus();

--- a/src/scripts/battlegrounds/battleground_alterac.cpp
+++ b/src/scripts/battlegrounds/battleground_alterac.cpp
@@ -5584,12 +5584,12 @@ void AddSC_bg_alterac()
     newscript->Name = "npc_AlteracBowman";
     newscript->GetAI = &GetAI_npc_AlteracBowman;
     newscript->RegisterSelf();
-
+    /*
     newscript = new Script;
     newscript->Name = "npc_AlteracDardosh";
     newscript->GetAI = &GetAI_npc_AlteracDardosh;
     newscript->RegisterSelf();
-
+    */
     newscript = new Script;
     newscript->Name = "npc_ram_wolf_tamed";
     newscript->GetAI = &GetAI_npc_ram_wolf_tamed;
@@ -5622,12 +5622,12 @@ void AddSC_bg_alterac()
     newscript->pGossipSelect = &GossipSelect_npc_AVBlood_collector;
     newscript->GetAI = &GetAI_npc_eventAV;
     newscript->RegisterSelf();
-
+    /*
     newscript = new Script;
     newscript->Name = "npc_ram_wolf_quest";
     newscript->pQuestRewardedNPC = &QuestComplete_AV_npc_ram_wolf;
     newscript->RegisterSelf();
-
+    */
     newscript = new Script;
     newscript->Name = "npc_ram_wolf_master";
     newscript->pGossipHello = &GossipHello_AV_npc_ram_wolf;

--- a/src/scripts/custom/custom.cpp
+++ b/src/scripts/custom/custom.cpp
@@ -19,6 +19,6 @@
 
 void AddSC_zero_scripts()
 {
-    AddSC_zero_creatures();
+    //AddSC_zero_creatures();
     AddSC_custom_creatures();
 }

--- a/src/scripts/custom/custom.h
+++ b/src/scripts/custom/custom.h
@@ -15,7 +15,7 @@
  */ 
 
 void AddSC_custom_creatures();
-void AddSC_zero_creatures();
+//void AddSC_zero_creatures();
 
 // used to call all scripts
 void AddSC_zero_scripts();

--- a/src/scripts/eastern_kingdoms/eastern_plaguelands/stratholme/stratholme.cpp
+++ b/src/scripts/eastern_kingdoms/eastern_plaguelands/stratholme/stratholme.cpp
@@ -1253,12 +1253,12 @@ void AddSC_stratholme()
     newscript->Name = "mobs_cristal_zuggurat";
     newscript->GetAI = &GetAI_mobs_cristal_zuggurat;
     newscript->RegisterSelf();
-
+    /*
     newscript = new Script;
     newscript->Name = "mobs_rat_pestifere";
     newscript->GetAI = &GetAI_mobs_rat_pestifere;
     newscript->RegisterSelf();
-
+    */
     newscript = new Script;
     newscript->Name = "npc_Aurius";
     newscript->GetAI = &GetAI_npc_aurius;

--- a/src/scripts/eastern_kingdoms/ironforge/ironforge.cpp
+++ b/src/scripts/eastern_kingdoms/ironforge/ironforge.cpp
@@ -241,12 +241,12 @@ void AddSC_ironforge()
     newscript->pGossipHello =  &GossipHello_npc_royal_historian_archesonus;
     newscript->pGossipSelect = &GossipSelect_npc_royal_historian_archesonus;
     newscript->RegisterSelf();
-
+    /*
     newscript = new Script;
     newscript->Name = "npc_magni_bronzebeard";
     newscript->pGossipHello   = &GossipHello_npc_magni_bronzebeard;
     newscript->RegisterSelf();
-
+    */
     newscript = new Script;
     newscript->Name = "npc_tinker_mekkatorque";
     newscript->pGossipHello   = &GossipHello_npc_tinker_mekkatorque;

--- a/src/scripts/eastern_kingdoms/silverpine_forest/shadowfang_keep/shadowfang_keep.cpp
+++ b/src/scripts/eastern_kingdoms/silverpine_forest/shadowfang_keep/shadowfang_keep.cpp
@@ -984,22 +984,22 @@ void AddSC_shadowfang_keep()
     newscript->pGossipSelect = &GossipSelect_npc_shadowfang_prisoner;
     newscript->GetAI = &GetAI_npc_shadowfang_prisoner;
     newscript->RegisterSelf();
-
+    /*
     newscript = new Script;
     newscript->Name = "mob_arugal_voidwalker";
     newscript->GetAI = &GetAI_mob_arugal_voidwalker;
     newscript->RegisterSelf();
-
+    */
     newscript = new Script;
     newscript->Name = "npc_arugal";
     newscript->GetAI = &GetAI_npc_arugal;
     newscript->RegisterSelf();
-
+    /*
     newscript = new Script;
     newscript->Name = "boss_arugal";
     newscript->GetAI = &GetAI_boss_arugal;
     newscript->RegisterSelf();
-
+    */
     newscript = new Script;
     newscript->Name = "npc_deathstalker_vincent";
     newscript->GetAI = &GetAI_npc_deathstalker_vincent;

--- a/src/scripts/eastern_kingdoms/stranglethorn_vale/stranglethorn_vale.cpp
+++ b/src/scripts/eastern_kingdoms/stranglethorn_vale/stranglethorn_vale.cpp
@@ -648,12 +648,12 @@ void AddSC_stranglethorn_vale()
     newscript->Name = "mob_yenniku";
     newscript->GetAI = &GetAI_mob_yenniku;
     newscript->RegisterSelf();
-
+    /*
     newscript = new Script;
     newscript->Name = "mob_assistant_kryll";
     newscript->GetAI = &GetAI_mob_assistant_kryll;
     newscript->RegisterSelf();
-
+    */
     newscript = new Script;
     newscript->Name = "go_transpolyporter";
     newscript->GOGetAI = &GetAIgo_transpolyporter;

--- a/src/scripts/eastern_kingdoms/stranglethorn_vale/zulgurub/boss_mandokir.cpp
+++ b/src/scripts/eastern_kingdoms/stranglethorn_vale/zulgurub/boss_mandokir.cpp
@@ -843,10 +843,11 @@ void AddSC_boss_mandokir()
     newscript->Name = "mob_chained_spirit";
     newscript->GetAI = &GetAI_mob_chained_spirit;
     newscript->RegisterSelf();
-
+    /*
     newscript = new Script;
     newscript->Name = "mob_vilebranche";
     newscript->GetAI = &GetAI_mob_vilebranche;
     newscript->RegisterSelf();
+    */
 }
 

--- a/src/scripts/eastern_kingdoms/stranglethorn_vale/zulgurub/zulgurub_trash.cpp
+++ b/src/scripts/eastern_kingdoms/stranglethorn_vale/zulgurub/zulgurub_trash.cpp
@@ -455,12 +455,12 @@ void AddSC_zg_trash()
     newscript->Name = "npc_gurubashi_berserker";
     newscript->GetAI = &GetAI_GurubashiBerserker;
     newscript->RegisterSelf();
-
+    /*
     newscript = new Script;
     newscript->Name = "npc_gurubashi_axethrower";
     newscript->GetAI = &GetAI_GurubashiAxeThrower;
     newscript->RegisterSelf();
-
+    */
     newscript = new Script;
     newscript->Name = "npc_hakkari_doctor";
     newscript->GetAI = &GetAI_npc_hakkari_doctor;
@@ -470,12 +470,12 @@ void AddSC_zg_trash()
     newscript->Name = "npc_esprit_vaudou";
     newscript->GetAI = &GetAI_npc_esprit_vaudou;
     newscript->RegisterSelf();
-
+    /*
     newscript = new Script;
     newscript->Name = "npc_fils_hakkar";
     newscript->GetAI = &GetAI_npc_fils_hakkar;
     newscript->RegisterSelf();
-
+    */
     newscript = new Script;
     newscript->Name = "go_pile_dechets";
     newscript->GOGetAI = &GetAIgo_pile_dechets;

--- a/src/scripts/kalimdor/silithus/ruins_of_ahnqiraj/boss_ossirian.cpp
+++ b/src/scripts/kalimdor/silithus/ruins_of_ahnqiraj/boss_ossirian.cpp
@@ -490,12 +490,12 @@ void AddSC_boss_ossirian()
     newscript->Name = "boss_ossirian";
     newscript->GetAI = &GetAI_boss_ossirian;
     newscript->RegisterSelf();
-
+    /*
     newscript = new Script;
     newscript->Name = "generic_random_move";
     newscript->GetAI = &GetAI_generic_random_move;
     newscript->RegisterSelf();
-
+    */
     newscript = new Script;
     newscript->Name = "ossirian_crystal";
     newscript->GOGetAI = &GetAI_ossirian_crystal;

--- a/src/scripts/kalimdor/silithus/ruins_of_ahnqiraj/ruins_of_ahnqiraj.cpp
+++ b/src/scripts/kalimdor/silithus/ruins_of_ahnqiraj/ruins_of_ahnqiraj.cpp
@@ -1423,12 +1423,12 @@ void AddSC_ruins_of_ahnqiraj()
     newscript->Name = "mob_anubisath_guardian";
     newscript->GetAI = &GetAI_mob_anubisath_guardian;
     newscript->RegisterSelf();
-
+    /*
     newscript = new Script;
     newscript->Name = "mob_anti_intrusion";
     newscript->GetAI = &GetAI_AntiIntrusion;
     newscript->RegisterSelf();
-
+    */
     newscript = new Script;
     newscript->Name = "mob_qiraji_swarmguard";
     newscript->GetAI = &GetAI_QirajiSwarmguard;
@@ -1498,12 +1498,12 @@ void AddSC_ruins_of_ahnqiraj()
     newscript->Name = "boss_tuubid";
     newscript->GetAI = &GetAI_Tuubid;
     newscript->RegisterSelf();
-
+    /*
     newscript = new Script;
     newscript->Name = "boss_yeggeth";
     newscript->GetAI = &GetAI_Yeggeth;
     newscript->RegisterSelf();
-
+    */
     newscript = new Script;
     newscript->Name = "boss_zerran";
     newscript->GetAI = &GetAI_Zerran;

--- a/src/scripts/kalimdor/silithus/silithus.cpp
+++ b/src/scripts/kalimdor/silithus/silithus.cpp
@@ -4054,12 +4054,12 @@ void AddSC_silithus()
     pNewScript->Name = "mob_HiveRegal_HunterKiller";
     pNewScript->GetAI = &GetAI_mob_HiveRegal_HunterKiller;
     pNewScript->RegisterSelf();
-
+    /*
     pNewScript = new Script;
     pNewScript->Name = "npc_Merok";
     pNewScript->GetAI = &GetAI_npc_Merok;
     pNewScript->RegisterSelf();
-
+    */
     pNewScript = new Script;
     pNewScript->Name = "npc_Shai";
     pNewScript->GetAI = &GetAI_npc_Shai;

--- a/src/scripts/kalimdor/the_barrens/razorfen_downs/razorfen_downs.cpp
+++ b/src/scripts/kalimdor/the_barrens/razorfen_downs/razorfen_downs.cpp
@@ -468,12 +468,12 @@ void AddSC_razorfen_downs()
     newscript->pGossipHello = &GossipHello_npc_henry_stern;
     newscript->pGossipSelect = &GossipSelect_npc_henry_stern;
     newscript->RegisterSelf();
-
+    /*
     newscript = new Script;
     newscript->Name = "go_holding_pen";
     newscript->pGOHello = &GOHello_go_holding_pen;
     newscript->RegisterSelf();
-
+    */
     newscript = new Script;
     newscript->Name = "boss_lady_faltheress";
     newscript->GetAI = &GetAI_boss_ladyFaltheress;
@@ -489,12 +489,12 @@ void AddSC_razorfen_downs()
     newscript->Name = "go_gong";
     newscript->pGOHello =           &GOHello_go_gong;
     newscript->RegisterSelf();
-
+    /*
     newscript = new Script;
     newscript->Name = "go_belnistrasz";
     newscript->pQuestRewardedGO = &GOQuestRewarded_go_belnistrasz;
     newscript->RegisterSelf();
-
+    */
     newscript = new Script;
     newscript->Name = "npc_tomb_creature";
     newscript->GetAI = &GetAI_npc_tomb_creature;

--- a/src/scripts/world/boss_lord_kazzak.cpp
+++ b/src/scripts/world/boss_lord_kazzak.cpp
@@ -342,10 +342,11 @@ void AddSC_boss_lord_kazzak()
     newscript->Name = "boss_lord_kazzak";
     newscript->GetAI = &GetAI_boss_lordkazzak;
     newscript->RegisterSelf();
-
+    /*
     newscript = new Script;
     newscript->Name = "boss_spirit_lord_kazzak";
     newscript->GetAI = &GetAI_boss_spirit_lordkazzak;
     newscript->RegisterSelf();
+    */
 }
 

--- a/src/scripts/world/npcs_special.cpp
+++ b/src/scripts/world/npcs_special.cpp
@@ -2718,12 +2718,12 @@ void AddSC_npcs_special()
     newscript->Name = "npc_pats_firework_guy";
     newscript->GetAI = &GetAI_npc_pats_firework_guy;
     newscript->RegisterSelf();
-
+    /*
     newscript = new Script;
     newscript->Name = "npc_firestarter_regular";
     newscript->GetAI = &GetAI_npc_firestarter_regular;
     newscript->RegisterSelf();
-
+    */
     newscript = new Script;
     newscript->Name = "npc_firestarter_show";
     newscript->GetAI = &GetAI_npc_firestarter_show;


### PR DESCRIPTION
This unregisters core scripts that are not used anywhere.

Fixes the following errors on startup:

> ERROR:Script registering but ScriptName npc_AlteracDardosh is not assigned in database. Script will not be used.
> ERROR:Script registering but ScriptName npc_ram_wolf_quest is not assigned in database. Script will not be used.
> ERROR:Script registering but ScriptName zero_boss_razorgore is not assigned in database. Script will not be used.
> ERROR:Script registering but ScriptName zero_Mob_Grethok_The_Controller is not assigned in database. Script will not be used.
> ERROR:Script registering but ScriptName boss_gmisland is not assigned in database. Script will not be used.
> ERROR:Script registering but ScriptName npc_attack_master is not assigned in database. Script will not be used.
> ERROR:Script registering but ScriptName npc_event_wave_mob is not assigned in database. Script will not be used.
> ERROR:Script registering but ScriptName npc_event_wave_mob_good is not assigned in database. Script will not be used.
> ERROR:Script registering but ScriptName npc_guard_master is not assigned in database. Script will not be used.
> ERROR:Script registering but ScriptName boss_spirit_lord_kazzak is not assigned in database. Script will not be used.
> ERROR:Script registering but ScriptName npc_firestarter_regular is not assigned in database. Script will not be used.
> ERROR:Script registering but ScriptName boss_mother_smolderweb is not assigned in database. Script will not be used.
> ERROR:Script registering but ScriptName boss_sneed_shredder is not assigned in database. Script will not be used.
> ERROR:Script registering but ScriptName boss_sneed is not assigned in database. Script will not be used.
> ERROR:Script registering but ScriptName boss_azshir_the_sleepless is not assigned in database. Script will not be used.
> ERROR:Script registering but ScriptName boss_kormok is not assigned in database. Script will not be used.
> ERROR:Script registering but ScriptName mob_arugal_voidwalker is not assigned in database. Script will not be used.
> ERROR:Script registering but ScriptName boss_arugal is not assigned in database. Script will not be used.
> ERROR:Script registering but ScriptName mobs_rat_pestifere is not assigned in database. Script will not be used.
> ERROR:Script registering but ScriptName boss_grilek is not assigned in database. Script will not be used.
> ERROR:Script registering but ScriptName boss_hazzarah is not assigned in database. Script will not be used.
> ERROR:Script registering but ScriptName mob_vilebranche is not assigned in database. Script will not be used.
> ERROR:Script registering but ScriptName boss_wushoolay is not assigned in database. Script will not be used.
> ERROR:Script registering but ScriptName npc_gurubashi_axethrower is not assigned in database. Script will not be used.
> ERROR:Script registering but ScriptName npc_fils_hakkar is not assigned in database. Script will not be used.
> ERROR:Script registering but ScriptName npc_magni_bronzebeard is not assigned in database. Script will not be used.
> ERROR:Script registering but ScriptName mob_assistant_kryll is not assigned in database. Script will not be used.
> ERROR:Script registering but ScriptName go_holding_pen is not assigned in database. Script will not be used.
> ERROR:Script registering but ScriptName go_belnistrasz is not assigned in database. Script will not be used.
> ERROR:Script registering but ScriptName generic_random_move is not assigned in database. Script will not be used.
> ERROR:Script registering but ScriptName mob_anti_intrusion is not assigned in database. Script will not be used.
> ERROR:Script registering but ScriptName boss_yeggeth is not assigned in database. Script will not be used.
> ERROR:Script registering but ScriptName npc_sandstalker is not assigned in database. Script will not be used.
> ERROR:Script registering but ScriptName npc_Merok is not assigned in database. Script will not be used.