### PR TITLE
Pets now retain more of their wild stats when running patches prior to 1.9

### DIFF
--- a/src/game/Objects/Pet.cpp
+++ b/src/game/Objects/Pet.cpp
@@ -1242,6 +1242,7 @@ bool Pet::InitStatsForLevel(uint32 petlevel, Unit* owner)
 
     SetLevel(petlevel);
 
+    // Before 1.9 pets retain their wild damage type
     if (sWorld.GetWowPatch() < WOW_PATCH_109)
         SetMeleeDamageSchool(SpellSchools(cinfo->dmgschool));
     else
@@ -1274,7 +1275,8 @@ bool Pet::InitStatsForLevel(uint32 petlevel, Unit* owner)
 
     int32 createResistance[MAX_SPELL_SCHOOL] = {0, 0, 0, 0, 0, 0, 0};
 
-    if (getPetType() != HUNTER_PET)
+    // Before 1.9 pets retain their wild resistances
+    if (getPetType() != HUNTER_PET || sWorld.GetWowPatch() < WOW_PATCH_109)
     {
         createResistance[SPELL_SCHOOL_HOLY]   = cinfo->resistance1;
         createResistance[SPELL_SCHOOL_FIRE]   = cinfo->resistance2;

--- a/src/game/Objects/Unit.cpp
+++ b/src/game/Objects/Unit.cpp
@@ -7736,8 +7736,9 @@ void Unit::UpdateSpeed(UnitMoveType mtype, bool forced, float ratio)
 
     if (GetTypeId() == TYPEID_UNIT)
     {
+        // Before patch 1.9 pets should retain their wild speed, after that they are normalised
         Creature* pCreature = (Creature*)this;
-        if (!(pCreature->IsPet() && pCreature->GetOwnerGuid().IsPlayer()))      // don't use DB values for player controlled pets
+        if (!(pCreature->IsPet() && pCreature->GetOwnerGuid().IsPlayer()) || sWorld.GetWowPatch() < WOW_PATCH_109)
         {
             switch (mtype)
             {


### PR DESCRIPTION
In accordance with the 1.9 patch notes (http://wowwiki.wikia.com/wiki/Patch_1.9#Pet_Changes) and sources linked in these reports:

https://elysium-project.org/bugtracker/issue/2877
https://elysium-project.org/bugtracker/issue/2940
#445 