### PR TITLE
Shapeshifting fixes 2

### DIFF
--- a/src/game/Objects/Unit.cpp
+++ b/src/game/Objects/Unit.cpp
@@ -9570,26 +9570,43 @@ bool Unit::isAttackReady(WeaponAttackType type) const
 }
 void Unit::SetDisplayId(uint32 modelId)
 {
-    float mod_x = 1;
-    switch (modelId)
+    if (IsPlayer())
     {
-    case 59:
-        mod_x *= DEFAULT_TAUREN_MALE_SCALE;
-        break;
-    case 60:
-        mod_x *= DEFAULT_TAUREN_FEMALE_SCALE;
-        break;
+        float mod_x = 1;
+        switch (modelId)
+        {
+        case 59:
+            mod_x *= DEFAULT_TAUREN_MALE_SCALE;
+            break;
+        case 60:
+            mod_x *= DEFAULT_TAUREN_FEMALE_SCALE;
+            break;
+        // Orb of Deception Gone
+        case 10148:
+            mod_x *= DEFAULT_TAUREN_MALE_SCALE;
+            break;
+        case 10149:
+            mod_x *= DEFAULT_TAUREN_FEMALE_SCALE;
+            break;
+        }
+        switch (GetDisplayId())
+        {
+        case 59:
+            mod_x /= DEFAULT_TAUREN_MALE_SCALE;
+            break;
+        case 60:
+            mod_x /= DEFAULT_TAUREN_FEMALE_SCALE;
+            break;
+            // Orb of Deception Gone
+        case 10148:
+            mod_x /= DEFAULT_TAUREN_MALE_SCALE;
+            break;
+        case 10149:
+            mod_x /= DEFAULT_TAUREN_FEMALE_SCALE;
+            break;
+        }
+        ApplyPercentModFloatValue(OBJECT_FIELD_SCALE_X, (mod_x -1)*100, true);
     }
-    switch (GetDisplayId())
-    {
-    case 59:
-        mod_x /= DEFAULT_TAUREN_MALE_SCALE;
-        break;
-    case 60:
-        mod_x /= DEFAULT_TAUREN_FEMALE_SCALE;
-        break;
-    }
-    ApplyPercentModFloatValue(OBJECT_FIELD_SCALE_X, (mod_x -1)*100, true);
 
     SetUInt32Value(UNIT_FIELD_DISPLAYID, modelId);
 

--- a/src/game/Objects/Unit.cpp
+++ b/src/game/Objects/Unit.cpp
@@ -9570,6 +9570,27 @@ bool Unit::isAttackReady(WeaponAttackType type) const
 }
 void Unit::SetDisplayId(uint32 modelId)
 {
+    float mod_x = 1;
+    switch (modelId)
+    {
+    case 59:
+        mod_x *= DEFAULT_TAUREN_MALE_SCALE;
+        break;
+    case 60:
+        mod_x *= DEFAULT_TAUREN_FEMALE_SCALE;
+        break;
+    }
+    switch (GetDisplayId())
+    {
+    case 59:
+        mod_x /= DEFAULT_TAUREN_MALE_SCALE;
+        break;
+    case 60:
+        mod_x /= DEFAULT_TAUREN_FEMALE_SCALE;
+        break;
+    }
+    ApplyPercentModFloatValue(OBJECT_FIELD_SCALE_X, (mod_x -1)*100, true);
+
     SetUInt32Value(UNIT_FIELD_DISPLAYID, modelId);
 
     UpdateModelData();
@@ -11429,10 +11450,6 @@ void Unit::InitPlayerDisplayIds()
         return;
 
     uint8 gender = getGender();
-    if (getRace() == RACE_TAUREN)
-        SetObjectScale(gender == GENDER_MALE ? DEFAULT_TAUREN_MALE_SCALE : DEFAULT_TAUREN_FEMALE_SCALE);
-    else
-        SetObjectScale(DEFAULT_OBJECT_SCALE);
 
     switch (gender)
     {

--- a/src/game/Spells/SpellAuras.cpp
+++ b/src/game/Spells/SpellAuras.cpp
@@ -1954,15 +1954,15 @@ std::pair<unsigned int, float> getShapeshiftModelInfo(ShapeshiftForm form, Unit 
             modelid = 892;
         else
             modelid = 8571;
-        mod = 0.75;
+        mod = 0.80;
         break;
     case FORM_TRAVEL:
         modelid = 632;
-        mod = 0.75;
+        mod = 0.80;
         break;
     case FORM_AQUA:
         modelid = 2428;
-        mod = 0.75;
+        mod = 0.80;
         break;
     case FORM_BEAR:
         if (Player::TeamForRace(target->getRace()) == ALLIANCE)
@@ -1985,7 +1985,7 @@ std::pair<unsigned int, float> getShapeshiftModelInfo(ShapeshiftForm form, Unit 
         break;
     case FORM_GHOSTWOLF:
         modelid = 4613;
-        mod = 0.75;
+        mod = 0.80;
         break;
     case FORM_MOONKIN:
         if (Player::TeamForRace(target->getRace()) == ALLIANCE)

--- a/src/game/Spells/SpellAuras.cpp
+++ b/src/game/Spells/SpellAuras.cpp
@@ -1944,11 +1944,77 @@ void Aura::HandleWaterBreathing(bool /*apply*/, bool /*Real*/)
         ((Player*)GetTarget())->UpdateMirrorTimers();
 }
 
+std::pair<unsigned int, float> getShapeshiftModelInfo(ShapeshiftForm form, Unit *target){
+    unsigned int modelid = 0;
+    float mod = 1;
+    switch (form)
+    {
+    case FORM_CAT:
+        if (Player::TeamForRace(target->getRace()) == ALLIANCE)
+            modelid = 892;
+        else
+            modelid = 8571;
+        mod = 0.75;
+        break;
+    case FORM_TRAVEL:
+        modelid = 632;
+        mod = 0.75;
+        break;
+    case FORM_AQUA:
+        modelid = 2428;
+        mod = 0.75;
+        break;
+    case FORM_BEAR:
+        if (Player::TeamForRace(target->getRace()) == ALLIANCE)
+            modelid = 2281;
+        else
+            modelid = 2289;
+        break;
+    case FORM_GHOUL:
+        if (Player::TeamForRace(target->getRace()) == ALLIANCE)
+            modelid = 10045;
+        break;
+    case FORM_DIREBEAR:
+        if (Player::TeamForRace(target->getRace()) == ALLIANCE)
+            modelid = 2281;
+        else
+            modelid = 2289;
+        break;
+    case FORM_CREATUREBEAR:
+        modelid = 902;
+        break;
+    case FORM_GHOSTWOLF:
+        modelid = 4613;
+        mod = 0.75;
+        break;
+    case FORM_MOONKIN:
+        if (Player::TeamForRace(target->getRace()) == ALLIANCE)
+            modelid = 15374;
+        else
+            modelid = 15375;
+        break;
+    case FORM_TREE:
+        modelid = 864;
+        break;
+    case FORM_SPIRITOFREDEMPTION:
+        modelid = 16031;
+        break;
+    /*case FORM_BATTLESTANCE:
+    case FORM_BERSERKERSTANCE:
+    case FORM_DEFENSIVESTANCE:
+    case FORM_AMBIENT:
+    case FORM_SHADOW:
+    case FORM_STEALTH:*/
+    default:
+        break;
+    }
+    return {modelid,mod};
+}
+
 void Aura::HandleAuraModShapeshift(bool apply, bool Real)
 {
-    uint32 modelid = 0;
-    float mod_x = 0.0f;
-    Powers PowerType = POWER_MANA;
+    if (!Real)
+        return;
     ShapeshiftForm form = ShapeshiftForm(m_modifier.m_miscvalue);
 
     Unit *target = GetTarget();
@@ -1960,145 +2026,95 @@ void Aura::HandleAuraModShapeshift(bool apply, bool Real)
         return;
     }
 
+    // remove polymorph before changing display id to keep new display id
     switch (form)
     {
         case FORM_CAT:
-        {
-            if (Player::TeamForRace(target->getRace()) == ALLIANCE)
-                modelid = 892;
-            else
-                modelid = 8571;
-            PowerType = POWER_ENERGY;
-            break;
-        }
+        case FORM_TREE:
         case FORM_TRAVEL:
-            modelid = 632;
-            break;
         case FORM_AQUA:
-            modelid = 2428;
-            break;
         case FORM_BEAR:
-        {
-            if (Player::TeamForRace(target->getRace()) == ALLIANCE)
-                modelid = 2281;
-            else
-                modelid = 2289;
-            PowerType = POWER_RAGE;
-            break;
-        }
-        case FORM_GHOUL:
-            if (Player::TeamForRace(target->getRace()) == ALLIANCE)
-                modelid = 10045;
-            break;
         case FORM_DIREBEAR:
-        {
-            if (Player::TeamForRace(target->getRace()) == ALLIANCE)
-                modelid = 2281;
-            else
-                modelid = 2289;
-            PowerType = POWER_RAGE;
-            break;
-        }
-        case FORM_CREATUREBEAR:
-            modelid = 902;
-            break;
-        case FORM_GHOSTWOLF:
-            modelid = 4613;
-            break;
         case FORM_MOONKIN:
         {
-            if (Player::TeamForRace(target->getRace()) == ALLIANCE)
-                modelid = 15374;
-            else
-                modelid = 15375;
+            // remove movement affects
+            target->RemoveSpellsCausingAura(SPELL_AURA_MOD_ROOT, GetHolder());
+            Unit::AuraList const& slowingAuras = target->GetAurasByType(SPELL_AURA_MOD_DECREASE_SPEED);
+            for (Unit::AuraList::const_iterator iter = slowingAuras.begin(); iter != slowingAuras.end();)
+            {
+                SpellEntry const* aurSpellInfo = (*iter)->GetSpellProto();
+
+                uint32 aurMechMask = aurSpellInfo->GetAllSpellMechanicMask();
+
+                // If spell that caused this aura has Croud Control or Daze effect
+                if ((aurMechMask & MECHANIC_NOT_REMOVED_BY_SHAPESHIFT) ||
+                        // some Daze spells have these parameters instead of MECHANIC_DAZE (skip snare spells)
+                        (aurSpellInfo->SpellIconID == 15 && aurSpellInfo->Dispel == 0 &&
+                        (aurMechMask & (1 << (MECHANIC_SNARE - 1))) == 0))
+                {
+                    ++iter;
+                    continue;
+                }
+
+                // All OK, remove aura now
+                target->RemoveAurasDueToSpellByCancel(aurSpellInfo->Id);
+                iter = slowingAuras.begin();
+            }
+
             break;
         }
+        default:
+            break;
+    }
+
+    std::pair<unsigned int, float> info = getShapeshiftModelInfo(form, target);
+    unsigned int modelid = info.first;
+    float mod_x = info.second;
+
+    if (modelid > 0 && !target->getTransForm())
+    {
+        if (apply)
+            target->SetDisplayId(modelid);
+        else
+            target->SetDisplayId(target->GetNativeDisplayId());
+        target->ApplyPercentModFloatValue(OBJECT_FIELD_SCALE_X, (mod_x -1)*100, apply);
+    }
+
+    if (!Real)
+        return;
+
+    if (apply)
+    {
+        Powers PowerType = POWER_MANA;
+        switch (form)
+        {
+        case FORM_CAT:
+            PowerType = POWER_ENERGY;
+            break;
+        case FORM_BEAR:
+        case FORM_DIREBEAR:
+            PowerType = POWER_RAGE;
+            break;
+        /*case FORM_TRAVEL:
+        case FORM_AQUA:
+        case FORM_GHOUL:
+        case FORM_CREATUREBEAR:
+        case FORM_GHOSTWOLF:
+        case FORM_MOONKIN:
         case FORM_AMBIENT:
         case FORM_SHADOW:
         case FORM_STEALTH:
-            break;
         case FORM_TREE:
-            modelid = 864;
+        case FORM_SPIRITOFREDEMPTION:
             break;
         case FORM_BATTLESTANCE:
         case FORM_BERSERKERSTANCE:
         case FORM_DEFENSIVESTANCE:
             PowerType = POWER_RAGE;
-            break;
-        case FORM_SPIRITOFREDEMPTION:
-            modelid = 16031;
-            break;
+            break;*/
         default:
             break;
-    }
-
-    // remove polymorph before changing display id to keep new display id
-    if (Real)
-    {
-        switch (form)
-        {
-            case FORM_CAT:
-            case FORM_TREE:
-            case FORM_TRAVEL:
-            case FORM_AQUA:
-            case FORM_BEAR:
-            case FORM_DIREBEAR:
-            case FORM_MOONKIN:
-            {
-                // remove movement affects
-                target->RemoveSpellsCausingAura(SPELL_AURA_MOD_ROOT, GetHolder());
-                Unit::AuraList const& slowingAuras = target->GetAurasByType(SPELL_AURA_MOD_DECREASE_SPEED);
-                for (Unit::AuraList::const_iterator iter = slowingAuras.begin(); iter != slowingAuras.end();)
-                {
-                    SpellEntry const* aurSpellInfo = (*iter)->GetSpellProto();
-
-                    uint32 aurMechMask = aurSpellInfo->GetAllSpellMechanicMask();
-
-                    // If spell that caused this aura has Croud Control or Daze effect
-                    if ((aurMechMask & MECHANIC_NOT_REMOVED_BY_SHAPESHIFT) ||
-                            // some Daze spells have these parameters instead of MECHANIC_DAZE (skip snare spells)
-                            (aurSpellInfo->SpellIconID == 15 && aurSpellInfo->Dispel == 0 &&
-                            (aurMechMask & (1 << (MECHANIC_SNARE - 1))) == 0))
-                    {
-                        ++iter;
-                        continue;
-                    }
-
-                    // All OK, remove aura now
-                    target->RemoveAurasDueToSpellByCancel(aurSpellInfo->Id);
-                    iter = slowingAuras.begin();
-                }
-
-                break;
-            }
-            default:
-                break;
         }
-    }
-
-    if (modelid > 0 && !target->getTransForm())
-    {
-        // fix Tauren shapeshift scaling
-        if (target->getRace() == RACE_TAUREN)
-        {
-            if (target->getGender() == GENDER_MALE)
-                mod_x = -25.9f; // 0.741 * 1.35 ~= 1.0
-            else
-                mod_x = -20.0f; // 0.8 * 1.25    = 1.0
-        }
-        
-        if (apply)
-            target->SetDisplayId(modelid);
-        else
-            target->SetDisplayId(target->GetNativeDisplayId());
-        target->ApplyPercentModFloatValue(OBJECT_FIELD_SCALE_X, mod_x, apply);
-    }
-    
-    if (!Real)
-        return;
-    
-    if (apply)
-    {
         // remove other shapeshift before applying a new one
         target->RemoveSpellsCausingAura(SPELL_AURA_MOD_SHAPESHIFT, GetHolder());
 
@@ -2209,14 +2225,15 @@ void Aura::HandleAuraModShapeshift(bool apply, bool Real)
 void Aura::HandleAuraTransform(bool apply, bool Real)
 {
     Unit *target = GetTarget();
+    float mod_x = 1;
     if (apply)
     {
         uint32 model_id;
-        
+
         // Discombobulate removes mount auras.
         if (GetId() == 4060 && Real)
             target->RemoveSpellsCausingAura(SPELL_AURA_MOUNTED);
-        
+
         // update active transform spell only not set or not overwriting negative by positive case
         if (!target->getTransForm() || !IsPositiveSpell(GetId()) || IsPositiveSpell(target->getTransForm()))
         {
@@ -2336,18 +2353,12 @@ void Aura::HandleAuraTransform(bool apply, bool Real)
                     ((Creature*)target)->LoadEquipment(ci->equipmentId, true);
             }
 
-            //fix tauren scaling
-            if (target->getRace() == RACE_TAUREN && target->GetDisplayId() == target->GetNativeDisplayId())
-            {
-                float mod_x = 0;
-                if (target->getGender() == GENDER_MALE)
-                    mod_x = -25.9f; // 0.741 * 1.35 ~= 1.0
-                else
-                    mod_x = -20.0f; // 0.8 * 1.25    = 1.0
-                target->ApplyPercentModFloatValue(OBJECT_FIELD_SCALE_X, mod_x, apply);
-            }
-            
-            target->SetDisplayId(model_id);
+            std::pair<unsigned int, float> info = getShapeshiftModelInfo(target->GetShapeshiftForm(), target);
+            if (target->GetDisplayId() == info.first)
+                mod_x /= info.second;
+
+            if (model_id)
+                target->SetDisplayId(model_id);
             target->setTransForm(GetId());
         }
     }
@@ -2363,16 +2374,6 @@ void Aura::HandleAuraTransform(bool apply, bool Real)
             if (target->GetTypeId() == TYPEID_UNIT)
                 ((Creature*)target)->LoadEquipment(((Creature*)target)->GetCreatureInfo()->equipmentId, true);
 
-            //fix tauren scaling
-            if (target->getRace() == RACE_TAUREN)
-            {
-                float mod_x = 0;
-                if (target->getGender() == GENDER_MALE)
-                    mod_x = -25.9f; // 0.741 * 1.35 ~= 1.0
-                else
-                    mod_x = -20.0f; // 0.8 * 1.25    = 1.0
-                target->ApplyPercentModFloatValue(OBJECT_FIELD_SCALE_X, mod_x, apply);
-            }
 
             // re-apply some from still active with preference negative cases
             Unit::AuraList const& otherTransforms = target->GetAurasByType(SPELL_AURA_TRANSFORM);
@@ -2393,12 +2394,14 @@ void Aura::HandleAuraTransform(bool apply, bool Real)
             }
             else //reapply shapeshifting, there should be only one.
             {
-                Unit::AuraList const& shapeshift = target->GetAurasByType(SPELL_AURA_MOD_SHAPESHIFT);
-                if (!shapeshift.empty() && !shapeshift.front()->IsInUse())
-                    shapeshift.front()->HandleAuraModShapeshift(true,false);
+                std::pair<unsigned int, float> info = getShapeshiftModelInfo(target->GetShapeshiftForm(), target);
+                mod_x /= info.second;
+                if (info.first)
+                    target->SetDisplayId(info.first);
             }
         }
     }
+    target->ApplyPercentModFloatValue(OBJECT_FIELD_SCALE_X, (mod_x -1)*100, apply);
 }
 
 void Aura::HandleForceReaction(bool apply, bool Real)

--- a/src/game/Spells/SpellAuras.cpp
+++ b/src/game/Spells/SpellAuras.cpp
@@ -2080,9 +2080,6 @@ void Aura::HandleAuraModShapeshift(bool apply, bool Real)
         target->ApplyPercentModFloatValue(OBJECT_FIELD_SCALE_X, (mod_x -1)*100, apply);
     }
 
-    if (!Real)
-        return;
-
     if (apply)
     {
         Powers PowerType = POWER_MANA;


### PR DESCRIPTION
- stop abusing `Real` flag in `HandleAuraModShapeshift`
- scaling fix for taurens has been moved to `SetDisplayId`
  - that will greatly help to prevent future issues with tauren scaling
  - as far as I can tell, display ids for players are not used for NPCs, so that should be safe
  - ~this also fixes Orb of Deception tauren scale~
- added scaling for Cat Form/Travel Form/Aquatic Form/Ghost Wolf as per https://elysium-project.org/bugtracker/issue/1657