### PR TITLE
SendLoot: refactored to avoid looking up when not needed.

### DIFF
--- a/src/game/CMakeLists.txt
+++ b/src/game/CMakeLists.txt
@@ -183,7 +183,8 @@ set (game_SRCS
 	Objects/Creature.cpp
 	Objects/DynamicObject.cpp
 	Objects/GameObject.cpp
-	Objects/Item.cpp
+        Objects/Item.cpp
+        Objects/Lootable.cpp
 	Objects/Object.cpp
 	Objects/Pet.cpp
 	Objects/Player.cpp
@@ -367,6 +368,7 @@ set (game_SRCS
 	Objects/GameObject.h
 	Objects/Item.h
 	Objects/ItemPrototype.h
+        Objects/Lootable.h
 	Objects/Object.h
 	Objects/Pet.h
 	Objects/Player.h

--- a/src/game/Handlers/SpellHandler.cpp
+++ b/src/game/Handlers/SpellHandler.cpp
@@ -240,7 +240,7 @@ void WorldSession::HandleOpenItemOpcode(WorldPacket& recvPacket)
         stmt.PExecute(pItem->GetGUIDLow());
     }
     else
-        pUser->SendLoot(pItem->GetObjectGuid(), LOOT_CORPSE);
+        pUser->SendLoot(pItem, LOOT_CORPSE);
 }
 
 void WorldSession::HandleGameObjectUseOpcode(WorldPacket & recv_data)

--- a/src/game/Objects/Corpse.h
+++ b/src/game/Objects/Corpse.h
@@ -27,6 +27,7 @@
 #include "Database/DatabaseEnv.h"
 #include "GridDefines.h"
 #include "LootMgr.h"
+#include "Lootable.h"
 
 enum CorpseType
 {
@@ -50,7 +51,7 @@ enum CorpseFlags
     CORPSE_FLAG_LOOTABLE    = 0x20
 };
 
-class Corpse : public WorldObject
+class Corpse : public WorldObject, public Lootable
 {
     public:
         explicit Corpse( CorpseType type = CORPSE_BONES );
@@ -83,7 +84,6 @@ class Corpse : public WorldObject
 
         bool isVisibleForInState(Player const* u, WorldObject const* viewPoint, bool inVisibleList) const;
 
-        Loot loot;                                          // remove insignia ONLY at BG
         Player* lootRecipient;
         bool lootForBody;
 
@@ -99,5 +99,11 @@ class Corpse : public WorldObject
         CorpseType m_type;
         time_t m_time;
         GridPair m_grid;                                    // gride for corpse position for fast search
+
+        // Object interface
+public:
+        bool prepareLoot(Player *reciever, LootType loot_type, Player *pVictim, PermissionTypes &permission) override;
 };
+
+
 #endif

--- a/src/game/Objects/Creature.h
+++ b/src/game/Objects/Creature.h
@@ -32,6 +32,7 @@
 #include "Database/DatabaseEnv.h"
 #include "CreatureGroups.h"
 #include "Cell.h"
+#include "Lootable.h"
 
 #include <list>
 
@@ -450,7 +451,7 @@ class ThreatListProcesser
         virtual bool Process(Unit* unit) = 0;
 };
 
-class MANGOS_DLL_SPEC Creature : public Unit
+class MANGOS_DLL_SPEC Creature : public Unit, public Lootable
 {
     CreatureAI *i_AI;
 
@@ -617,7 +618,6 @@ class MANGOS_DLL_SPEC Creature : public Unit
         virtual void DeleteFromDB();                        // overwrited in Pet
         static void DeleteFromDB(uint32 lowguid, CreatureData const* data);
 
-        Loot loot;
         bool lootForPickPocketed;
         bool lootForBody;
         bool lootForSkin;
@@ -881,7 +881,13 @@ class MANGOS_DLL_SPEC Creature : public Unit
     private:
         GridReference<Creature> m_gridRef;
         CreatureInfo const* m_creatureInfo;
+
+        // Lootable interface
+public:
+        bool prepareLoot(Player *reciever, LootType loot_type, Player *pVictim, PermissionTypes &permission) override;
 };
+
+
 
 class AssistDelayEvent : public BasicEvent
 {

--- a/src/game/Objects/GameObject.h
+++ b/src/game/Objects/GameObject.h
@@ -27,6 +27,7 @@
 #include "Object.h"
 #include "LootMgr.h"
 #include "Database/DatabaseEnv.h"
+#include "Lootable.h"
 
 // GCC have alternative #pragma pack(N) syntax and old gcc version not support pack(push,N), also any gcc version not support it at some platform
 #if defined( __GNUC__ )
@@ -541,7 +542,7 @@ struct GameObjectDisplayInfoEntry;
 
 #define GO_ANIMPROGRESS_DEFAULT 100                         // in 3.x 0xFF
 
-class MANGOS_DLL_SPEC GameObject : public WorldObject
+class MANGOS_DLL_SPEC GameObject : public WorldObject, public Lootable
 {
     public:
         explicit GameObject();
@@ -662,8 +663,6 @@ class MANGOS_DLL_SPEC GameObject : public WorldObject
 
         void SaveRespawnTime();
 
-        Loot        loot;
-
         bool HasQuest(uint32 quest_id) const;
         bool HasInvolvedQuest(uint32 quest_id) const;
         bool ActivateToQuest(Player *pTarget) const;
@@ -736,5 +735,11 @@ class MANGOS_DLL_SPEC GameObject : public WorldObject
         void SwitchDoorOrButton(bool activate, bool alternative = false);
 
         GridReference<GameObject> m_gridRef;
+
+        // Lootable interface
+public:
+        bool prepareLoot(Player *reciever, LootType loot_type, Player *pVictim, PermissionTypes &permission) override;
 };
+
+
 #endif

--- a/src/game/Objects/Item.h
+++ b/src/game/Objects/Item.h
@@ -26,6 +26,7 @@
 #include "Object.h"
 #include "LootMgr.h"
 #include "ItemPrototype.h"
+#include "Lootable.h"
 
 class SpellEntry;
 class Bag;
@@ -230,7 +231,7 @@ struct ItemRequiredTarget
 
 bool ItemCanGoIntoBag(ItemPrototype const *proto, ItemPrototype const *pBagProto);
 
-class MANGOS_DLL_SPEC Item : public Object
+class MANGOS_DLL_SPEC Item : public Object, public Lootable
 {
     public:
         static Item* CreateItem(uint32 item, uint32 count, Player const* player = NULL);
@@ -320,8 +321,6 @@ class MANGOS_DLL_SPEC Item : public Object
         int32 GetSpellCharges(uint8 index/*0..5*/ = 0) const { return GetInt32Value(ITEM_FIELD_SPELL_CHARGES + index); }
         void SetSpellCharges(uint8 index/*0..5*/, int32 value) { SetInt32Value(ITEM_FIELD_SPELL_CHARGES + index,value); }
 
-        Loot loot;
-
         void SetLootState(ItemLootUpdateState state);
         bool HasGeneratedLoot() const { return m_lootState != ITEM_LOOT_NONE && m_lootState != ITEM_LOOT_REMOVED; }
         bool HasTemporaryLoot() const { return m_lootState == ITEM_LOOT_TEMPORARY; }
@@ -374,6 +373,12 @@ class MANGOS_DLL_SPEC Item : public Object
          * @return false iif the Item is corrupt.
          */
         bool WakeUp();
+
+        // Lootable interface
+public:
+        bool prepareLoot(Player *reciever, LootType loot_type, Player *pVictim, PermissionTypes &permission) override;
 };
+
+
 
 #endif

--- a/src/game/Objects/Lootable.cpp
+++ b/src/game/Objects/Lootable.cpp
@@ -1,0 +1,22 @@
+/************************************************************************
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+************************************************************************/
+#include "Lootable.h"
+
+
+Lootable::Lootable(const WorldObject *lootTarget, uint32 gold) :
+    loot(lootTarget, gold)
+{
+
+}

--- a/src/game/Objects/Lootable.h
+++ b/src/game/Objects/Lootable.h
@@ -1,0 +1,29 @@
+/************************************************************************
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+************************************************************************/
+#ifndef LOOTABLE_H
+#define LOOTABLE_H
+
+#include "Object.h"
+#include "LootMgr.h"
+
+class Lootable
+{
+public:
+    virtual bool prepareLoot(Player *reciever, LootType loot_type, Player *pVictim, PermissionTypes &permission) = 0;
+    Lootable(WorldObject const* lootTarget, uint32 gold = 0);
+    Loot loot;
+};
+
+#endif // LOOTABLE_H

--- a/src/game/Objects/Player.h
+++ b/src/game/Objects/Player.h
@@ -43,6 +43,7 @@
 #include "SharedDefines.h"
 #include "SpellMgr.h"
 #include "HonorMgr.h"
+#include "Lootable.h"
 
 #include <string>
 #include <vector>
@@ -1756,7 +1757,8 @@ class MANGOS_DLL_SPEC Player final: public Unit
         PlayerMenu* PlayerTalkClass;
         std::vector<ItemSetEffect *> ItemSetEff;
 
-        void SendLoot(ObjectGuid guid, LootType loot_type, Player* pVictim = NULL);
+        void SendLoot(Lootable *obj, LootType loot_type, Player *pVictim = nullptr);
+        void SendLoot(ObjectGuid guid, LootType loot_type, Player* pVictim = nullptr);
         void SendLootRelease(ObjectGuid guid );
         void SendNotifyLootItemRemoved(uint8 lootSlot);
         void SendNotifyLootMoneyRemoved();

--- a/src/game/Spells/SpellEffects.cpp
+++ b/src/game/Spells/SpellEffects.cpp
@@ -3010,7 +3010,7 @@ void Spell::EffectPickPocket(SpellEffectIndex /*eff_idx*/)
 
     // victim have to be alive and humanoid or undead
     if (unitTarget->isAlive() && (unitTarget->GetCreatureTypeMask() & CREATURE_TYPEMASK_HUMANOID_OR_UNDEAD) != 0)
-        ((Player*)m_caster)->SendLoot(unitTarget->GetObjectGuid(), LOOT_PICKPOCKETING);
+        ((Player*)m_caster)->SendLoot((Creature *)unitTarget, LOOT_PICKPOCKETING);
 }
 
 void Spell::EffectAddFarsight(SpellEffectIndex eff_idx)
@@ -4944,7 +4944,7 @@ void Spell::EffectDisEnchant(SpellEffectIndex /*eff_idx*/)
     Player* pCaster = static_cast<Player*>(m_caster);
 
     pCaster->UpdateCraftSkill(m_spellInfo->Id);
-    pCaster->SendLoot(itemTarget->GetObjectGuid(), LOOT_DISENCHANTING);
+    pCaster->SendLoot(itemTarget, LOOT_DISENCHANTING);
 
     // quick solution to prevent exploiting; this will cause items loss on full bags though
     // in order to fix this correctly have to fix first plMover->SendLootRelease(lootGuid); @ MovementHandler
@@ -5268,7 +5268,7 @@ void Spell::EffectSkinning(SpellEffectIndex /*eff_idx*/)
 
     uint32 skill = creature->GetCreatureInfo()->GetRequiredLootSkill();
 
-    ((Player*)m_caster)->SendLoot(creature->GetObjectGuid(), LOOT_SKINNING);
+    ((Player*)m_caster)->SendLoot(creature, LOOT_SKINNING);
     creature->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_SKINNABLE);
 
     int32 reqValue = targetLevel < 10 ? 0 : targetLevel < 20 ? (targetLevel - 10) * 10 : targetLevel * 5;
@@ -5745,7 +5745,7 @@ void Spell::EffectSkinPlayerCorpse(SpellEffectIndex eff_idx)
         corpseTarget->SetFlag(CORPSE_FIELD_DYNAMIC_FLAGS, CORPSE_DYNFLAG_LOOTABLE);
         corpseTarget->loot.gold = m_caster->getLevel();
         corpseTarget->lootRecipient = m_caster->ToPlayer();
-        m_caster->ToPlayer()->SendLoot(corpseTarget->GetObjectGuid(), LOOT_INSIGNIA);
+        m_caster->ToPlayer()->SendLoot(corpseTarget, LOOT_INSIGNIA);
     }
 }
 void Spell::EffectBind(SpellEffectIndex eff_idx)


### PR DESCRIPTION
Looking up for `Object`s possibly involves concurrency, impacting performances.

Refactor brief:
- Created a base class `Lootable` inherited by `Object`s subclasses currently owning a `Loot` field.
- Created a `SendLoot` function taking a pointer to a `Lootable` instead of a guid
- former `SendLoot` is now a wrapper
- moved object type depending code to `prepareLoot` in each `Lootable`