### PR TITLE
Player death fixes

### DIFF
--- a/src/game/Objects/Player.cpp
+++ b/src/game/Objects/Player.cpp
@@ -1302,11 +1302,10 @@ void Player::Update(uint32 update_diff, uint32 p_time)
     }
 
     // not auto-free ghost from body in instances
-    if (m_deathTimer > 0  && !GetMap()->Instanceable())
+    if (getDeathState() == CORPSE  && !GetMap()->Instanceable())
     {
         if (p_time >= m_deathTimer)
         {
-            m_deathTimer = 0;
             BuildPlayerRepop();
             RepopAtGraveyard();
         }
@@ -4670,6 +4669,7 @@ void Player::RepopAtGraveyard()
 
     // stop countdown until repop
     m_deathTimer = 0;
+    SetDeathState(DEAD);
     UpdateObjectVisibility();
     // if no grave found, stay at the current location
     // and don't show spirit healer location
@@ -7109,9 +7109,8 @@ void Player::RemovedInsignia(Player* looterPlr)
         return;
 
     // If not released spirit, do it !
-    if (m_deathTimer > 0)
+    if (getDeathState() != DEAD)
     {
-        m_deathTimer = 0;
         BuildPlayerRepop();
         RepopAtGraveyard();
     }
@@ -17118,11 +17117,11 @@ bool Player::IsVisibleInGridForPlayer(Player* pl) const
         return true;
 
     // Live player see live player or dead player with not realized corpse
-    if (pl->isAlive() || pl->m_deathTimer > 0)
-        return isAlive() || m_deathTimer > 0;
+    if (pl->getDeathState() != DEAD)
+        return getDeathState() != DEAD;
 
     // Ghost see other friendly ghosts, that's for sure
-    if (!(isAlive() || m_deathTimer > 0) && IsFriendlyTo(pl))
+    if (getDeathState() == DEAD && IsFriendlyTo(pl))
         return true;
 
     // Dead player see live players near own corpse

--- a/src/game/Objects/Unit.h
+++ b/src/game/Objects/Unit.h
@@ -370,8 +370,8 @@ enum DeathState
 {
     ALIVE          = 0,                                     // show as alive
     JUST_DIED      = 1,                                     // temporary state at die, for creature auto converted to CORPSE, for player at next update call
-    CORPSE         = 2,                                     // corpse state, for player this also meaning that player not leave corpse
-    DEAD           = 3,                                     // for creature despawned state (corpse despawned), for player CORPSE/DEAD not clear way switches (FIXME), and use m_deathtimer > 0 check for real corpse state
+    CORPSE         = 2,                                     // corpse state, for player spirit is still within the corpse
+    DEAD           = 3,                                     // for creature despawned state (corpse despawned), for player spirit has been released (player is ghost)
     JUST_ALIVED    = 4,                                     // temporary state at resurrection, for creature auto converted to ALIVE, for player at next update call
     CORPSE_FALLING = 5                                      // corpse state in case when corpse still falling to ground
 };


### PR DESCRIPTION
Fixed player DeathState.
If a player relog while dead (as ghosts):
- his ghost will no longer become visible to the livings
- he will no longer be teleported back to the graveyard when his corpse is removed (e.g. insignia removed in battlegrounds)
