### PR TITLE
Make mailed Honor Marks expire

### DIFF
--- a/src/game/Battlegrounds/BattleGround.cpp
+++ b/src/game/Battlegrounds/BattleGround.cpp
@@ -845,7 +845,7 @@ void BattleGround::SendRewardMarkByMail(Player *plr, uint32 mark, uint32 count)
 
         MailDraft(subject, textBuf)
         .AddItem(markItem)
-        .SendMailTo(plr, MailSender(MAIL_CREATURE, bmEntry), MAIL_CHECK_MASK_COPIED, 1 * HOUR, 3 * DAY);
+        .SendMailTo(plr, MailSender(MAIL_CREATURE, bmEntry), MAIL_CHECK_MASK_COPIED, 15 * MINUTE, 1 * DAY);
     }
 }
 

--- a/src/game/Battlegrounds/BattleGround.cpp
+++ b/src/game/Battlegrounds/BattleGround.cpp
@@ -845,7 +845,7 @@ void BattleGround::SendRewardMarkByMail(Player *plr, uint32 mark, uint32 count)
 
         MailDraft(subject, textBuf)
         .AddItem(markItem)
-        .SendMailTo(plr, MailSender(MAIL_CREATURE, bmEntry), MAIL_CHECK_MASK_NONE, 0, 3 * DAY);
+        .SendMailTo(plr, MailSender(MAIL_CREATURE, bmEntry), MAIL_CHECK_MASK_COPIED, 1 * HOUR, 3 * DAY);
     }
 }
 


### PR DESCRIPTION
Honor Marks could be stored in the Mail Box indefinitely