### PR TITLE
Fix to ranged mobs double attack

### DIFF
--- a/sql/migrations/20170515222637_world.sql
+++ b/sql/migrations/20170515222637_world.sql
@@ -1,0 +1,7 @@
+INSERT INTO `migrations` VALUES ('20170515222637');
+
+-- Fix to ranged mobs attacking twice on agro
+UPDATE creature_ai_scripts cas
+SET cas.action1_type=23, cas.action1_param1=1, cas.action1_param2=0, cas.action2_type=0, cas.action2_param1=0
+where event_type = 4 and action1_param1 IN (674,6660,9483,10277,12548,15547,15620,15736,15795,16100,17228,18164,22121,22907)
+and creature_id IN (select creature_id from (SELECT * FROM creature_ai_scripts) as temp where event_type = 9 and action1_param1 = cas.action1_param1);


### PR DESCRIPTION
https://github.com/elysium-project/server/issues/638 **Ranged mobs double attack when pulled**

The issue here is that the EventAI for most ranged mobs has one rule to cast a spell on agro and another to cast it while in phase 1, so on agro the spell will be cast twice. 

In most cases its not an issue since the mob will be busy casting the first spell to cast the second, but some specific spells have no cast time and no cooldown so the mob will cast it twice.
I removed the "on agro" spell from these specific cases.

List of mobs affected below.