### PR TITLE
Weapon skill fix

### DIFF
--- a/src/game/Objects/Unit.cpp
+++ b/src/game/Objects/Unit.cpp
@@ -2738,11 +2738,11 @@ float Unit::MeleeSpellMissChance(Unit *pVictim, WeaponAttackType attType, int32 
 
     // PvP - PvE melee chances
     if (pVictim->GetTypeId() == TYPEID_PLAYER)
-        hitChance = 95.0f + skillDiff * 0.04f;
+        hitChance = 94.4f + skillDiff * 0.04f;
     else if (skillDiff < -10)
-        hitChance = 93.0f + (skillDiff + 10) * 0.4f;        // 7% base chance to miss for big skill diff (%6 in 3.x)
+        hitChance = 93.4f + (skillDiff + 10) * 0.4f;        // 7% ~ 6.60% base chance to miss for big skill diff
     else
-        hitChance = 95.0f + skillDiff * 0.1f;
+        hitChance = 94.4f + skillDiff * 0.1f;
 
     // Hit chance depends from victim auras
     if (attType == RANGED_ATTACK)
@@ -3079,8 +3079,8 @@ float Unit::MeleeMissChanceCalc(const Unit *pVictim, WeaponAttackType attType) c
     if (!pVictim)
         return 0.0f;
 
-    // Base misschance 5%
-    float missChance = 5.0f;
+    // Base misschance 5.60%
+    float missChance = 5.60f;
 
     // DualWield - white damage has additional 19% miss penalty
     if (haveOffhandWeapon() && attType != RANGED_ATTACK)
@@ -3104,7 +3104,7 @@ float Unit::MeleeMissChanceCalc(const Unit *pVictim, WeaponAttackType attType) c
     if (pVictim->GetTypeId() == TYPEID_PLAYER)
         missChance -= skillDiff * 0.04f;
     else if (skillDiff < -10)
-        missChance -= (skillDiff + 10) * 0.4f - 2.0f;       // 7% base chance to miss for big skill diff (%6 in 3.x)
+        missChance -= (skillDiff + 10) * 0.4f + 1.0f;       // 7% ~ 6.60% base chance to miss for big skill diff
     else
         missChance -=  skillDiff * 0.1f;
 

--- a/src/game/Objects/Unit.cpp
+++ b/src/game/Objects/Unit.cpp
@@ -3104,7 +3104,7 @@ float Unit::MeleeMissChanceCalc(const Unit *pVictim, WeaponAttackType attType) c
     if (pVictim->GetTypeId() == TYPEID_PLAYER)
         missChance -= skillDiff * 0.04f;
     else if (skillDiff < -10)
-        missChance -= (skillDiff + 10) * 0.4f + 1.0f;       // 7% ~ 6.60% base chance to miss for big skill diff
+        missChance -= (skillDiff + 10) * 0.4f - 1.0f;       // 7% ~ 6.60% base chance to miss for big skill diff
     else
         missChance -=  skillDiff * 0.1f;
 


### PR DESCRIPTION
The existing melee/ranged miss calculation based on weapon skill shows some deficits that aren't in line with existing research, particular an erroneous "bump" of skill between two specific weapon skill values. They also completely devalue half the weapon skill items by providing zero benefit (+hit can only be obtained in full intervals), both of those phenomena were not present in vanilla WoW.

Shown below is the weapon skill effects on hit/miss chance shown side by side between new and old formula:
![](http://i.imgur.com/NFPw0m7.png)

Clearly shown is the massive bump in hitrate when going from 304 to 305 weapon skill (effectively 2% hit) that has no business being there. The corrected formula smoothes the transition between large and small weapon skill formulas by adjusting the hitcap by 0.4%, resulting in a value of 8.60%, an often quoted figure with tons of research behind it, as opposed to the 9% currently implemented on the server. Further, the lower cap is raised by an equal amount to 5.60% and while this figure has less research, the figure of 5.60% is present **everywhere**, from defense skill crit calculations, to mob crit strike chances, etc. and as such a reasonable assumption can be made that the 0.6% difference in base miss chance is valid from the 5% currently active on the server.

To summarize, these would be the effects of implementing these changes:
- Scaling remains unchanged (0.1% at higher differences, 0.4% at lower)
- Scaling switch point (the point at which the weapon skill formulas switch over) remains unchanged
- Hitcap with 300 weapon skill is lowered from 9.00% to 8.60%, effectively no change
- Hitcap with 304 weapon skill (Maladath, Anubisath Warhammer, etc.) is lowered from 7.40% to 7.00%, effectively 1%
- Hitcap with 305 weapon skill (racials) is raised from 6.00% to 6.60%, effectively 1%
- Hitcap with 307 weapon skill (Edgemasters) is raised from 5.80% to 6.40%, effectively 1%
- Hitcap with 312 weapon skill (racial + Edgemasters) is raised from 5.30% to 5.90%, effectively no change, although it should be noted that with the corrected formula you gain an extra 1% hit over just the racial 305 skill