### PR TITLE
Transform scaling improvements and Dartol's Rod + Orb of Deception fix

### DIFF
--- a/src/game/Objects/Creature.cpp
+++ b/src/game/Objects/Creature.cpp
@@ -277,7 +277,8 @@ bool Creature::InitEntry(uint32 Entry, Team team, CreatureData const* data /*=NU
     SetEntry(Entry);                                        // normal entry always
     m_creatureInfo = cinfo;                                 // map mode related always
 
-    SetObjectScale(cinfo->scale);
+    SetObjectScale(DEFAULT_OBJECT_SCALE);
+    setNativeScale(cinfo->scale);
 
     // equal to player Race field, but creature does not have race
     SetByteValue(UNIT_FIELD_BYTES_0, 0, 0);

--- a/src/game/Objects/Player.cpp
+++ b/src/game/Objects/Player.cpp
@@ -2800,17 +2800,6 @@ void Player::InitStatsForLevel(bool reapplyMods)
     // set default cast time multiplier
     SetFloatValue(UNIT_MOD_CAST_SPEED, 1.0f);
 
-    // Reset Size Before Reapplying Auras
-    if (getRace() == RACE_TAUREN)
-    {
-        if (getGender() == GENDER_MALE)
-            SetObjectScale(DEFAULT_TAUREN_MALE_SCALE);
-        else
-            SetObjectScale(DEFAULT_TAUREN_FEMALE_SCALE);
-    }
-    else
-        SetObjectScale(DEFAULT_OBJECT_SCALE);
-
     // save base values (bonuses already included in stored stats)
     for (int i = STAT_STRENGTH; i < MAX_STATS; ++i)
         SetCreateStat(Stats(i), info.stats[i]);

--- a/src/game/Objects/Unit.cpp
+++ b/src/game/Objects/Unit.cpp
@@ -11332,6 +11332,11 @@ void Unit::RemoveAllSpellCooldown()
 
 void Unit::setTransformScale(float scale)
 {
+    if (!scale)
+    {
+        sLog.outError("Attempt to set transform scale to 0!");
+        return;
+    }
     ApplyPercentModFloatValue(OBJECT_FIELD_SCALE_X,(scale/m_nativeScaleOverride -1)*100,true);
     m_nativeScaleOverride = scale;
 }

--- a/src/game/Objects/Unit.cpp
+++ b/src/game/Objects/Unit.cpp
@@ -9614,44 +9614,6 @@ bool Unit::isAttackReady(WeaponAttackType type) const
 }
 void Unit::SetDisplayId(uint32 modelId)
 {
-    if (IsPlayer())
-    {
-        float mod_x = 1;
-        switch (modelId)
-        {
-        case 59:
-            mod_x *= DEFAULT_TAUREN_MALE_SCALE;
-            break;
-        case 60:
-            mod_x *= DEFAULT_TAUREN_FEMALE_SCALE;
-            break;
-        // Orb of Deception Gone
-        case 10148:
-            mod_x *= DEFAULT_TAUREN_MALE_SCALE;
-            break;
-        case 10149:
-            mod_x *= DEFAULT_TAUREN_FEMALE_SCALE;
-            break;
-        }
-        switch (GetDisplayId())
-        {
-        case 59:
-            mod_x /= DEFAULT_TAUREN_MALE_SCALE;
-            break;
-        case 60:
-            mod_x /= DEFAULT_TAUREN_FEMALE_SCALE;
-            break;
-            // Orb of Deception Gone
-        case 10148:
-            mod_x /= DEFAULT_TAUREN_MALE_SCALE;
-            break;
-        case 10149:
-            mod_x /= DEFAULT_TAUREN_FEMALE_SCALE;
-            break;
-        }
-        ApplyPercentModFloatValue(OBJECT_FIELD_SCALE_X, (mod_x -1)*100, true);
-    }
-
     SetUInt32Value(UNIT_FIELD_DISPLAYID, modelId);
 
     UpdateModelData();
@@ -11368,6 +11330,28 @@ void Unit::RemoveAllSpellCooldown()
     }
 }
 
+void Unit::setTransformScale(float scale)
+{
+    ApplyPercentModFloatValue(OBJECT_FIELD_SCALE_X,(scale/m_nativeScaleOverride -1)*100,true);
+    m_nativeScaleOverride = scale;
+}
+
+void Unit::resetTransformScale()
+{
+    setTransformScale(getNativeScale());
+}
+
+float Unit::getNativeScale() const
+{
+    return m_nativeScale;
+}
+
+void Unit::setNativeScale(float scale)
+{
+    setTransformScale(scale);
+    m_nativeScale = scale;
+}
+
 void Unit::CooldownEvent(SpellEntry const *spellInfo, uint32 itemId, Spell* spell)
 {
     // start cooldowns at server side, if any
@@ -11527,12 +11511,17 @@ void Unit::InitPlayerDisplayIds()
         case GENDER_FEMALE:
             SetDisplayId(info->displayId_f);
             SetNativeDisplayId(info->displayId_f);
+            if (getRace() == RACE_TAUREN)
+                setNativeScale(DEFAULT_TAUREN_FEMALE_SCALE);
             break;
         case GENDER_MALE:
             SetDisplayId(info->displayId_m);
             SetNativeDisplayId(info->displayId_m);
+            if (getRace() == RACE_TAUREN)
+                setNativeScale(DEFAULT_TAUREN_MALE_SCALE);
             break;
         default:
             return;
     }
+
 }

--- a/src/game/Objects/Unit.cpp
+++ b/src/game/Objects/Unit.cpp
@@ -11511,6 +11511,7 @@ void Unit::InitPlayerDisplayIds()
 
     uint8 gender = getGender();
 
+    SetObjectScale(DEFAULT_OBJECT_SCALE);
     switch (gender)
     {
         case GENDER_FEMALE:

--- a/src/game/Objects/Unit.h
+++ b/src/game/Objects/Unit.h
@@ -1903,6 +1903,11 @@ class MANGOS_DLL_SPEC Unit : public WorldObject
         GlobalCooldownMgr& GetGlobalCooldownMgr() { return m_GlobalCooldownMgr; }
 
         void RemoveAllSpellCooldown();
+
+        void setTransformScale(float scale);
+        void resetTransformScale();
+        float getNativeScale() const;
+        void setNativeScale(float scale);
     protected:
         explicit Unit ();
 
@@ -2001,6 +2006,9 @@ class MANGOS_DLL_SPEC Unit : public WorldObject
         GuardianPetList m_guardianPets;
 
         ObjectGuid m_TotemSlot[MAX_TOTEM_SLOT];
+
+        float m_nativeScale = 1;
+        float m_nativeScaleOverride = 1;
 
         // Error traps for some wrong args using
         // this will catch and prevent build for any cases when all optional args skipped and instead triggered used non boolean type

--- a/src/game/Spells/SpellAuras.cpp
+++ b/src/game/Spells/SpellAuras.cpp
@@ -2262,77 +2262,58 @@ void Aura::HandleAuraTransform(bool apply, bool Real)
                 {
                     case 16739:                                 // Orb of Deception
                     {
-                        uint32 orb_model = target->GetNativeDisplayId();
-                        switch (orb_model)
+                        uint8 gender = sObjectMgr.GetCreatureModelInfo(target->GetDisplayId())->gender;
+                        switch (target->getRace())
                         {
-                            // Troll Female
-                            case 1479:
-                                model_id = 10134;
-                                break;
-                            // Troll Male
-                            case 1478:
-                                model_id = 10135;
-                                break;
-                            // Tauren Male
-                            case 59:
-                                model_id = 10136;
-                                break;
-                            // Human Male
-                            case 49:
-                                model_id = 10137;
-                                break;
-                            // Human Female
-                            case 50:
-                                model_id = 10138;
-                                break;
-                            // Orc Male
-                            case 51:
-                                model_id = 10139;
-                                break;
-                            // Orc Female
-                            case 52:
-                                model_id = 10140;
-                                break;
-                            // Dwarf Male
-                            case 53:
-                                model_id = 10141;
-                                break;
-                            // Dwarf Female
-                            case 54:
-                                model_id = 10142;
-                                break;
-                            // NightElf Male
-                            case 55:
-                                model_id = 10143;
-                                break;
-                            // NightElf Female
-                            case 56:
-                                model_id = 10144;
-                                break;
-                            // Undead Female
-                            case 58:
-                                model_id = 10145;
-                                break;
-                            // Undead Male
-                            case 57:
-                                model_id = 10146;
-                                break;
-                            // Tauren Female
-                            case 60:
-                                model_id = 10147;
-                                break;
-                            // Gnome Male
-                            case 1563:
+                        case RACE_TROLL:
+                            model_id = gender == GENDER_MALE ?
+                                        10135 :
+                                        10134 ;
+                            break;
+                        case RACE_TAUREN:
+                            model_id = gender == GENDER_MALE ?
+                                        10136 :
+                                        10147 ;
+                            break;
+                        case RACE_HUMAN:
+                            model_id = gender == GENDER_MALE ?
+                                        10137 :
+                                        10138 ;
+                            break;
+                        case RACE_ORC:
+                            model_id = gender == GENDER_MALE ?
+                                        10139 :
+                                        10140 ;
+                            break;
+                        case RACE_DWARF:
+                            model_id = gender == GENDER_MALE ?
+                                        10141 :
+                                        10142 ;
+                            break;
+                        case RACE_NIGHTELF:
+                            model_id = gender == GENDER_MALE ?
+                                        10143 :
+                                        10144 ;
+                            break;
+                        case RACE_UNDEAD:
+                            model_id = gender == GENDER_MALE ?
+                                        10146 :
+                                        10145 ;
+                            break;
+                        case RACE_GNOME:
+                            if (gender == GENDER_MALE)
+                            {
                                 model_id = 10148;
                                 mod_x = DEFAULT_TAUREN_MALE_SCALE;
-                                break;
-                            // Gnome Female
-                            case 1564:
+                            }
+                            else
+                            {
                                 model_id = 10149;
                                 mod_x = DEFAULT_TAUREN_FEMALE_SCALE;
-                                break;
-                            default:
-                                break;
+                            }
+                            break;
+                        default:
+                            break;
                         }
                         break;
                     }

--- a/src/game/Spells/SpellAuras.cpp
+++ b/src/game/Spells/SpellAuras.cpp
@@ -2069,19 +2069,24 @@ void Aura::HandleAuraModShapeshift(bool apply, bool Real)
 
     std::pair<unsigned int, float> info = getShapeshiftModelInfo(form, target);
     unsigned int modelid = info.first;
-    float mod_x = info.second;
-
     if (modelid > 0 && !target->getTransForm())
     {
         if (apply)
+        {
+            target->setTransformScale(info.second);
             target->SetDisplayId(modelid);
+        }
         else
+        {
+            target->resetTransformScale();
             target->SetDisplayId(target->GetNativeDisplayId());
-        target->ApplyPercentModFloatValue(OBJECT_FIELD_SCALE_X, (mod_x -1)*100, apply);
+        }
     }
 
     if (apply)
     {
+
+
         Powers PowerType = POWER_MANA;
         switch (form)
         {
@@ -2222,10 +2227,10 @@ void Aura::HandleAuraModShapeshift(bool apply, bool Real)
 void Aura::HandleAuraTransform(bool apply, bool Real)
 {
     Unit *target = GetTarget();
-    float mod_x = 1;
     if (apply)
     {
-        uint32 model_id;
+        float mod_x = 1;
+        uint32 model_id = 0;
 
         // Discombobulate removes mount auras.
         if (GetId() == 4060 && Real)
@@ -2319,10 +2324,12 @@ void Aura::HandleAuraTransform(bool apply, bool Real)
                             // Gnome Male
                             case 1563:
                                 model_id = 10148;
+                                mod_x = DEFAULT_TAUREN_MALE_SCALE;
                                 break;
                             // Gnome Female
                             case 1564:
                                 model_id = 10149;
+                                mod_x = DEFAULT_TAUREN_FEMALE_SCALE;
                                 break;
                             default:
                                 break;
@@ -2350,12 +2357,11 @@ void Aura::HandleAuraTransform(bool apply, bool Real)
                     ((Creature*)target)->LoadEquipment(ci->equipmentId, true);
             }
 
-            std::pair<unsigned int, float> info = getShapeshiftModelInfo(target->GetShapeshiftForm(), target);
-            if (target->GetDisplayId() == info.first)
-                mod_x /= info.second;
-
             if (model_id)
+            {
                 target->SetDisplayId(model_id);
+                target->setTransformScale(mod_x);
+            }
             target->setTransForm(GetId());
         }
     }
@@ -2366,6 +2372,7 @@ void Aura::HandleAuraTransform(bool apply, bool Real)
         {
             target->setTransForm(0);
             target->SetDisplayId(target->GetNativeDisplayId());
+            target->resetTransformScale();
 
             // apply default equipment for creature case
             if (target->GetTypeId() == TYPEID_UNIT)
@@ -2392,13 +2399,14 @@ void Aura::HandleAuraTransform(bool apply, bool Real)
             else //reapply shapeshifting, there should be only one.
             {
                 std::pair<unsigned int, float> info = getShapeshiftModelInfo(target->GetShapeshiftForm(), target);
-                mod_x /= info.second;
                 if (info.first)
+                {
                     target->SetDisplayId(info.first);
+                    target->setTransformScale(info.second);
+                }
             }
         }
     }
-    target->ApplyPercentModFloatValue(OBJECT_FIELD_SCALE_X, (mod_x -1)*100, apply);
 }
 
 void Aura::HandleForceReaction(bool apply, bool Real)


### PR DESCRIPTION
Transform scaling:
- added members to `Unit` to keep track of the ~model~ transform depending scale through transformation and shapeshifting processes.

  member                            | usage
  --------------------------------|----------------------------------------
  `float m_nativeScale`                | storage for scale of NativeDisplayId
  `float m_nativeScaleOverride`  | storage for scale of currently active Transform or Shapeshift
  `void setTransformScale(float)`         | undo the current `m_nativeScaleOverride` and apply the new one
  `void setNativeScale(float)`                | set the native scale and apply it through `setTransformScale`
  `void resetTransformScale()`      | reset to `m_nativeScaleOverride` through `setTransformScale`
  `float getNativeScale()`               | returns  `m_nativeScale`

Orb of Deception:
- no longer based on NativeDisplayId
  - picks race from `getRace()`
  - picks gender from DisplayId
    - Dartol's Rod + Orb of Deception now works