### PR TITLE
Battleground: improved AB banner animation responsivness

### DIFF
--- a/src/game/Battlegrounds/BattleGroundAB.cpp
+++ b/src/game/Battlegrounds/BattleGroundAB.cpp
@@ -339,6 +339,8 @@ void BattleGroundAB::EventPlayerClickedOnFlag(Player *source, GameObject* target
     uint8 event = (sBattleGroundMgr.GetGameObjectEventIndex(target_obj->GetGUIDLow())).event1;
     if (event >= BG_AB_NODES_MAX)                           // not a node
         return;
+
+    target_obj->SendObjectDeSpawnAnim(target_obj->GetObjectGuid());
     BG_AB_Nodes node = BG_AB_Nodes(event);
 
     BattleGroundTeamIndex teamIndex = GetTeamIndexByTeamId(source->GetTeam());

--- a/src/game/Battlegrounds/BattleGroundAV.cpp
+++ b/src/game/Battlegrounds/BattleGroundAV.cpp
@@ -1249,6 +1249,7 @@ void BattleGroundAV::EventPlayerClickedOnFlag(Player *source, GameObject* target
     uint8 event = (sBattleGroundMgr.GetGameObjectEventIndex(target_obj->GetGUIDLow())).event1;
     if (event >= BG_AV_NODES_MAX)                           // not a node
         return;
+    target_obj->SendObjectDeSpawnAnim(target_obj->GetObjectGuid());
     BG_AV_Nodes node = BG_AV_Nodes(event);
     switch ((sBattleGroundMgr.GetGameObjectEventIndex(target_obj->GetGUIDLow())).event2 % BG_AV_MAX_STATES)
     {


### PR DESCRIPTION
Arathi banners will burn as soon as they are assaulted/defended, new banners will still be delayed.
