### PR TITLE
Regrowth and Ferocious Bite coefficients

### DIFF
--- a/sql/migrations/20170526010757_world.sql
+++ b/sql/migrations/20170526010757_world.sql
@@ -1,0 +1,3 @@
+INSERT INTO migrations VALUES ('20170526010757');
+
+UPDATE spell_bonus_data SET direct_bonus=0.325, dot_bonus=0.0733 WHERE entry=8936;

--- a/src/game/Spells/SpellEffects.cpp
+++ b/src/game/Spells/SpellEffects.cpp
@@ -417,9 +417,10 @@ void Spell::EffectSchoolDMG(SpellEffectIndex effect_idx)
                 // Ferocious Bite
                 if (m_spellInfo->IsFitToFamilyMask<CF_DRUID_RIP_BITE>() && m_spellInfo->SpellVisual == 6587)
                 {
-                    // converts each extra point of energy into ($f1+$AP/630) additional damage
-                    float multiple = m_caster->GetTotalAttackPowerValue(BASE_ATTACK) / 630 + m_spellInfo->DmgMultiplier[effect_idx];
-                    damage += int32(m_caster->GetPower(POWER_ENERGY) * multiple);
+					// ( AP * 3% * combo + energy * 2,7 + damage )
+					if (uint32 combo = ((Player*)m_caster)->GetComboPoints())
+						damage += int32(m_caster->GetTotalAttackPowerValue(BASE_ATTACK) * combo * 0.03f);
+                    damage += int32(m_caster->GetPower(POWER_ENERGY) * m_spellInfo->DmgMultiplier[effect_idx]);
                     m_caster->SetPower(POWER_ENERGY, 0);
                 }
                 break;

--- a/src/game/Spells/SpellEffects.cpp
+++ b/src/game/Spells/SpellEffects.cpp
@@ -417,9 +417,9 @@ void Spell::EffectSchoolDMG(SpellEffectIndex effect_idx)
                 // Ferocious Bite
                 if (m_spellInfo->IsFitToFamilyMask<CF_DRUID_RIP_BITE>() && m_spellInfo->SpellVisual == 6587)
                 {
-					// ( AP * 3% * combo + energy * 2,7 + damage )
-					if (uint32 combo = ((Player*)m_caster)->GetComboPoints())
-						damage += int32(m_caster->GetTotalAttackPowerValue(BASE_ATTACK) * combo * 0.03f);
+                    // ( AP * 3% * combo + energy * 2,7 + damage )
+                    if (uint32 combo = ((Player*)m_caster)->GetComboPoints())
+                        damage += int32(m_caster->GetTotalAttackPowerValue(BASE_ATTACK) * combo * 0.03f);
                     damage += int32(m_caster->GetPower(POWER_ENERGY) * m_spellInfo->DmgMultiplier[effect_idx]);
                     m_caster->SetPower(POWER_ENERGY, 0);
                 }


### PR DESCRIPTION
Related issue that doesn't offer any info: https://github.com/elysium-project/server/issues/801

**Regrowth**

Every source on the internet has Regrowth using the general hybrid spell rules except the Theorycraft addon. TC has entirely different values. 
I also found this statement:
> Currently, the equations are unknown for hybrid healing spells. Several equations have been proposed, but none of them provide correct results for all (or most) hybrid spells. Because there are so few hybrid healing spells, it may be the case that their coefficients are not set by equations at all, but are chosen directly by the developers.
https://quot3druid.wordpress.com/category/restoration-druid-pve-healing/5-talents-and-spells/c-research-and-comparisons/

Using this video as a source: https://www.youtube.com/watch?v=9-6K-IDhOdA

Healing bonus: 1030 (top right corner)
Regrowth ticks: 240
Regrowth heals: 1496 / 1473 / 1428 / 1468 (1466 average)

DoT coefficient:
(1064\*1.1 + (1030\*x)) = 240*7
x = 0.494757

Direct coefficient:
(1061.5\*1.1 + (1030\*x)) = 1466
x = 0.28966

These values are much closer to Theorycraft than the general spell rules, updating Regrowth to use TC instead: 32.5% direct and 51.3% dot.
Previous values were 20% and 63%.


**Ferocious Bite**

Theres a list of skills that keep being copy pasted around without any source: 
>There are only 6 abilities that gain damage bonuses from your attack power. These are:
>Eviscerate - 3% per combo point
>Ferocious Bite - 3% per combo point
>Garrote - 18% - 3% per tick (6)
>Rake - 6% - 2% per tick (3)
>Rip - 24% - 4% per tick (6)
>Rupture - 24% - amount per tick and number of ticks based on CP

The source for the rogue skills is their old wowwiki entries, the formulas all match and Elysium is already using them.
Rake is incorrect, AP scaling is a TBC change: http://wowwiki.wikia.com/wiki/Rake?oldid=349782
Confirmed it in this 1.12 video, its not getting anything from AP: https://www.youtube.com/watch?v=tXgsBdLQfvU

Ferocious Bite currently has some strange formula on Elysium, attack power is modifying the "2.7 adicional damage" modifier which makes no sense. I found zero sources mentioning this formula and looking at the cmangos git log it has remained unchanged since the initial commit in 2008.

Wowwiki mentions a 0,1526 value: http://wowwiki.wikia.com/wiki/Ferocious_Bite?oldid=276851
But this was most likely calculated using it with 5 combo points, most sources agree on the 3% per combo rule: https://github.com/ccshiro/cc-buglist/issues/11
And it makes sense for it to scale with combo points, just like Eviscerate.

Added in 1.12:
> In addition, Ferocious Bite now increases in potency with greater attack power.
>http://wow.gamepedia.com/Patch_1.12.0

Unchanged in TBC:
>Still seems to be 15% of AP 
>http://wow.allakhazam.com/forum.html?forum=243&mid=1166267315131686088

Implemented the 3% * combo * AP rule and removed the old formula.



