### PR TITLE
Make spells which should ignore armor behave correctly

### DIFF
--- a/src/game/Objects/Unit.cpp
+++ b/src/game/Objects/Unit.cpp
@@ -1439,6 +1439,14 @@ void Unit::CalculateSpellDamage(SpellNonMeleeDamage *damageInfo, int32 damage, S
                 damageInfo->HitInfo |= SPELL_HIT_TYPE_CRIT;
                 damage = SpellCriticalDamageBonus(spellInfo, damage, pVictim, spell);
             }
+
+            if (damage > 0)
+            {
+                // SPELL_CUSTOM_IGNORE_ARMOR should not be necessary anymore after realizing spells of DmgClass NONE or MAGIC
+                // ignore armor, while RANGED and MELEE don't.
+                if (damageSchoolMask & SPELL_SCHOOL_MASK_NORMAL && !(spellInfo->Custom & SPELL_CUSTOM_IGNORE_ARMOR))
+                    damage = CalcArmorReducedDamage(pVictim, damage);
+            }
         }
         break;
         // Magical Attacks
@@ -1459,15 +1467,8 @@ void Unit::CalculateSpellDamage(SpellNonMeleeDamage *damageInfo, int32 damage, S
         break;
     }
 
-    // damage mitigation
-    if (damage > 0)
-    {
-        // physical damage => armor
-        if (damageSchoolMask & SPELL_SCHOOL_MASK_NORMAL && !(spellInfo->Custom & SPELL_CUSTOM_IGNORE_ARMOR))
-            damage = CalcArmorReducedDamage(pVictim, damage);
-    }
-    else
-        damage = 0;
+    damage = std::max(damage, 0);
+
     damageInfo->damage = damage;
 }
 


### PR DESCRIPTION
I found myself with a spell that was not ignoring armor, but watching vanilla videos it was clear it should be ignoring armor from the damage it did. After looking at the properties of this particular spell, I realized it was of spell school type SPELL_SCHOOL_NORMAL, but damage class SPELL_DAMAGE_CLASS_MAGIC.

After finding all spells with this particular combo of spell school and damage class, I found that many of them were spells that had been modified to ignore armor in our core (through the db field Custom, in spell_mod table). 

Further I found that other spells which were customized in our db to ignore armor, were of damage class type SPELL_DAMAGE_CLASS_NONE. 

When looking at the function `Unit::CalculateSpellDamage` in our core, we can see that spells of damage class SPELL_DAMAGE_CLASS_RANGED and SPELL_DAMAGE_CLASS_MELEE are calculated using melee damage calculations, while spells of damage class SPELL_DAMAGE_CLASS_NONE and SPELL_DAMAGE_CLASS_MAGIC use spell damage calculations.

This all leads me to believe that any spell of damage class SPELL_DAMAGE_CLASS_NONE or SPELL_DAMAGE_CLASS_MAGIC should ignore armor, and it makes a whole lot of sense when we look at the types of spell which would be affected by this change: 

https://pastebin.com/1G502cf9

The pastebin contains all spells where the spell school type is SPELL_SCHOOL_NORMAL, but the damage class is SPELL_DAMAGE_CLASS_NONE or SPELL_DAMAGE_CLASS_MAGIC. As mentioned, several of these spells are already customized to ignore armor (`SELECT * FROM spell_mod where Custom = 32;`), some are not.

This PR would make all the spells in the above pastebin ignore armor.