### PR TITLE
Make hostile mobs attack nearby passive escort npcs

### DIFF
--- a/src/game/AI/ScriptedEscortAI.cpp
+++ b/src/game/AI/ScriptedEscortAI.cpp
@@ -340,7 +340,15 @@ void npc_escortAI::ResetEscort()
 
 void npc_escortAI::UpdateEscortAI(const uint32 uiDiff)
 {
-    //Check if we have a current target
+    // Make nearby enemies aggro passive escort npcs
+    if (HasEscortState(STATE_ESCORT_ESCORTING) && !m_creature->isInCombat())
+    {
+        if (Unit* pTarget = m_creature->SelectNearestHostileUnitInAggroRange(true))
+            if ((pTarget->GetTypeId() == TYPEID_UNIT) && !pTarget->GetCharmInfo() && !pTarget->isInCombat())
+                pTarget->AI()->AttackStart(m_creature);
+    }
+
+    // Check if we have a current target
     if (!m_creature->SelectHostileTarget() || !m_creature->getVictim())
         return;
 


### PR DESCRIPTION
Currently passive escort npcs don't get attacked by aggressive hostile mobs. The escorted mob will join combat if the player is attacked, but aggressive mobs on the way wont aggro the escort npc first. This means escort quests can be completely trivialized if the player just stands away from the path of spawned mobs, and he can complete the quest without fighting a single mob. A good example is the chicken escort quest in the Hinterlands. If you get away from the road, all the spawned mobs just walk past the chicken and don't aggro.

This issue does not happen with aggressive escort npcs like the Defias Traitor in Westfall, because they initiate the attack first. The problem is that aggressive mobs will never aggro the escort npc if it is passive.

This is a proposed fix to make escort npcs attacked by aggressive hostile mobs in aggro range. It won't aggro other passive or friendly creatures, just those that are aggressive (red) and should attack everything in range. It fixes the exploit in the Hinterlands quest.