### PR TITLE
Implement Quest Disable

### DIFF
--- a/src/game/ObjectMgr.cpp
+++ b/src/game/ObjectMgr.cpp
@@ -3319,7 +3319,7 @@ void ObjectMgr::LoadQuests()
 
         // additional quest integrity checks (GO, creature_template and item_template must be loaded already)
 
-        if (qinfo->GetQuestMethod() >= 3)
+        if (qinfo->GetQuestMethod() >= QUEST_METHOD_LIMIT)
             sLog.outErrorDb("Quest %u has `Method` = %u, expected values are 0, 1 or 2.", qinfo->GetQuestId(), qinfo->GetQuestMethod());
 
         if (qinfo->m_SpecialFlags > QUEST_SPECIAL_FLAG_DB_ALLOWED)

--- a/src/game/QuestDef.cpp
+++ b/src/game/QuestDef.cpp
@@ -130,7 +130,16 @@ Quest::Quest(Field * questRecord)
     QuestStartScript = questRecord[123].GetUInt32();
     QuestCompleteScript = questRecord[124].GetUInt32();
 
-    m_isActive = (QuestMethod & 1)? false : true;
+    m_isActive = true;
+
+    if (QuestMethod & QUEST_METHOD_DISABLED)
+    {
+        // Leave invalid entries to be caught by ObjectMgr
+        if (QuestMethod <= QUEST_METHOD_LIMIT)
+            QuestMethod = QUEST_METHOD_DISABLED;
+
+        m_isActive = false;
+    }
 
     m_reqitemscount = 0;
     m_reqCreatureOrGOcount = 0;

--- a/src/game/QuestDef.cpp
+++ b/src/game/QuestDef.cpp
@@ -130,7 +130,7 @@ Quest::Quest(Field * questRecord)
     QuestStartScript = questRecord[123].GetUInt32();
     QuestCompleteScript = questRecord[124].GetUInt32();
 
-    m_isActive = true;
+    m_isActive = (1 == QuestMethod)? false : true;
 
     m_reqitemscount = 0;
     m_reqCreatureOrGOcount = 0;

--- a/src/game/QuestDef.cpp
+++ b/src/game/QuestDef.cpp
@@ -130,7 +130,7 @@ Quest::Quest(Field * questRecord)
     QuestStartScript = questRecord[123].GetUInt32();
     QuestCompleteScript = questRecord[124].GetUInt32();
 
-    m_isActive = (1 == QuestMethod)? false : true;
+    m_isActive = (QuestMethod & 1)? false : true;
 
     m_reqitemscount = 0;
     m_reqCreatureOrGOcount = 0;

--- a/src/game/QuestDef.h
+++ b/src/game/QuestDef.h
@@ -175,6 +175,15 @@ enum QuestSpecialFlags
     QUEST_SPECIAL_FLAG_TIMED                = 0x040,        // Internal flag computed only
 };
 
+enum QuestMethod
+{
+    QUEST_METHOD_AUTOCOMPLETE               = 0x0,
+    QUEST_METHOD_DISABLED                   = 0x1,
+    QUEST_METHOD_DELIVER                    = 0x2,
+
+    QUEST_METHOD_LIMIT                      = 0x3,          // Highest Method entry DB should have
+};
+
 #define QUEST_SPECIAL_FLAG_DB_ALLOWED (QUEST_SPECIAL_FLAG_REPEATABLE | QUEST_SPECIAL_FLAG_EXPLORATION_OR_EVENT)
 
 struct QuestLocale


### PR DESCRIPTION
Untested, but should work fine.

Quests can now be disabled with Method |= 1,
and returned to original state with Method &= 2 (or 6)