### PR TITLE
Reworked spell cast proc handling to keep track of procced spells

### DIFF
--- a/src/game/Objects/Unit.h
+++ b/src/game/Objects/Unit.h
@@ -934,6 +934,7 @@ struct ProcTriggeredData
     uint32 procFlag;
 };
 
+typedef std::unordered_map<uint32, bool> TriggeredAuraMapType;
 typedef std::list< ProcTriggeredData > ProcTriggeredList;
 
 enum TeleportToOptions
@@ -1183,9 +1184,9 @@ class MANGOS_DLL_SPEC Unit : public WorldObject
 
         void PetOwnerKilledUnit(Unit* pVictim);
 
-        void ProcDamageAndSpell(Unit *pVictim, uint32 procAttacker, uint32 procVictim, uint32 procEx, uint32 amount, WeaponAttackType attType = BASE_ATTACK, SpellEntry const *procSpell = nullptr, Spell* spell = nullptr);
-        void ProcDamageAndSpellFor(bool isVictim, Unit * pTarget, uint32 procFlag, uint32 procExtra, WeaponAttackType attType, SpellEntry const* procSpell, uint32 damage, ProcTriggeredList& triggeredList, Spell* spell = nullptr);
-        void HandleTriggers(Unit *pVictim, uint32 procExtra, uint32 amount, SpellEntry const *procSpell, ProcTriggeredList const& procTriggered);
+        void ProcDamageAndSpell(Unit *pVictim, uint32 procAttacker, uint32 procVictim, uint32 procEx, uint32 amount, WeaponAttackType attType = BASE_ATTACK, SpellEntry const *procSpell = nullptr, Spell* spell = nullptr, TriggeredAuraMapType *triggeredAuraMap = nullptr);
+        void ProcDamageAndSpellFor(bool isVictim, Unit * pTarget, uint32 procFlag, uint32 procExtra, WeaponAttackType attType, SpellEntry const* procSpell, uint32 damage, ProcTriggeredList& triggeredList, Spell* spell = nullptr, TriggeredAuraMapType *triggeredAuraMap = nullptr);
+        void HandleTriggers(Unit *pVictim, uint32 procExtra, uint32 amount, SpellEntry const *procSpell, ProcTriggeredList const& procTriggered, TriggeredAuraMapType *triggeredAuraMap = nullptr);
 
         void HandleEmote(uint32 emote_id);                  // auto-select command/state
         void HandleEmoteCommand(uint32 emote_id);

--- a/src/game/Spells/Spell.h
+++ b/src/game/Spells/Spell.h
@@ -625,6 +625,7 @@ class Spell
         typedef std::list<SpellEntry const*> SpellInfoList;
         SpellInfoList m_TriggerSpells;                      // casted by caster to same targets settings in m_targets at success finish of current spell
         SpellInfoList m_preCastSpells;                      // casted by caster to each target at spell hit before spell effects apply
+        TriggeredAuraMapType triggeredAuraMap;              // A map to spell aura IDs which have been procced by this spell to prevent multi-procs
 
         uint32 m_spellState;
         uint32 m_timer;

--- a/src/game/Spells/SpellMgr.cpp
+++ b/src/game/Spells/SpellMgr.cpp
@@ -1074,6 +1074,62 @@ SpellCastResult GetErrorAtShapeshiftedCast(SpellEntry const *spellInfo, uint32 f
     return SPELL_CAST_OK;
 }
 
+bool IsTriggerAuraAllowedMultipleProc(SpellEntry const* spellInfo)
+{
+    // An aura which can proc multiple times is allowed to proc for each target
+    // hit in a spell cast
+    switch (spellInfo->Id)
+    {
+        // Inspiration (priest talent) can proc on all targets affected by Prayer of Healing
+        case 14892:
+        case 15362:
+        case 15363:
+        // Deep Wounds (warrior talent) crit bleed, can proc on all targets hit (cleave/ww)
+        case 12834:
+        case 12849:
+        case 12867:
+        // Healing Way (shaman talent) can proc on all targets with T1 8-set
+        case 29206:
+        case 29205:
+        case 29202:
+            return true;
+        default:
+            return false;
+    }
+}
+
+bool IsTriggerAuraSingleProcPerCast(SpellEntry const* spellInfo)
+{
+    // An aura which is a single proc per cast has a chance to proc on ALL targets hit
+    // but can only proc ONCE on those targets (i.e. PER CAST, but depends on target
+    // damage info)
+    // Known cases: Master of Elements (mage talent)
+    //              Sweeping Strikes (warrior skill), first target could be a miss
+    switch (spellInfo->Id)
+    {
+        // Master of Elements
+        case 29074:
+        case 29075:
+        case 29076:
+        // Sweeping Strikes
+        case 12292:
+            return true;
+        default:
+            return false;
+    }
+}
+
+bool IsTriggerAuraSingleChancePerCast(SpellEntry const* spellInfo)
+{
+    // The assumption is that any aura which is not allowed multiple procs per
+    // cast, and is not a single proc per cast only has 1 chance to proc on
+    // the cast, i.e. Regardless of the number of targets hit, the aura can
+    // only have 1 chance to proc, such as on the first target
+    // Known cases: Clearcasting (mage/shaman talents)
+    //              All other procs
+    return !IsTriggerAuraAllowedMultipleProc(spellInfo) && !IsTriggerAuraSingleProcPerCast(spellInfo);
+}
+
 void SpellMgr::LoadSpellTargetPositions()
 {
     mSpellTargetPositions.clear();                                // need for reload case

--- a/src/game/Spells/SpellMgr.h
+++ b/src/game/Spells/SpellMgr.h
@@ -439,6 +439,10 @@ inline bool IsReflectableSpell(SpellEntry const* spellInfo, Unit* caster = NULL,
       && !spellInfo->HasAttribute(SPELL_ATTR_PASSIVE) && !IsPositiveSpell(spellInfo, caster, victim);
 }
 
+bool IsTriggerAuraAllowedMultipleProc(SpellEntry const* spellInfo);
+bool IsTriggerAuraSingleProcPerCast(SpellEntry const* spellInfo);
+bool IsTriggerAuraSingleChancePerCast(SpellEntry const* spellInfo);
+
 inline bool NeedsComboPoints(SpellEntry const* spellInfo)
 {
     return (spellInfo->AttributesEx & (SPELL_ATTR_EX_REQ_TARGET_COMBO_POINTS | SPELL_ATTR_EX_REQ_COMBO_POINTS));


### PR DESCRIPTION
PR #645 solved the issue with spells proccing some auras multiple times for the most part, but introduced another problem with the mage Master of Elements talent (#954 #853), which can proc for any crit when using an AoE spell, but only proc once. Similarly, when Whirlwind was used with Sweeping Strikes active, if the first target was a non-hit, SS would not proc on the other successful hits.

The current implementation had no way to handle these sorts of cases. Some auras share proc flags, and we don't calculate if the spell is a crit until applying effects on the target. Therefore, we can't just check if there's a crit and use it in an pre-target-processing proc like for Blizzard and Clearcasting, nor can we add the appropriate flag to the target when it is a crit because the flag is shared with other procs (i.e. Clearcasting). We could potentially move procs to the last target hit, where we would know crit information from previous targets, but that wouldn't work for SS and WW either, and it'd be a pretty dodgy fix.

Instead, I've implemented a map which tracks IDs of auras that have procced for the caster on a spell cast (for all targets), and prevents them from being able to be triggered again based on customisable functions and known behaviours. The fixes in PR #645 are now applied using this, and the newly introduced issues with MoE are also fixed. 

As a side note, this should also improve the performance of proc handling slightly, as it prevents auras which cannot actually proc anything from being checked multiple times (since we check all player auras for procs).