### PR TITLE
Fixes compilation of tools on GNU/Linux.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -183,7 +183,7 @@ if(NOT USE_STD_MALLOC)
   
 endif()
 
-# Win32 delifered packages
+# Win32 delivered packages
 if(WIN32)
   set(MYSQL_INCLUDE_DIR ${CMAKE_SOURCE_DIR}/dep/include/mysql)
   set(MYSQL_LIBRARY ${CMAKE_SOURCE_DIR}/dep/lib/${DEP_ARCH}_release/libmySQL.lib)
@@ -191,6 +191,10 @@ if(WIN32)
   set(OPENSSL_INCLUDE_DIR ${CMAKE_SOURCE_DIR}/dep/include/openssl)
   set(OPENSSL_LIBRARIES ${CMAKE_SOURCE_DIR}/dep/lib/${DEP_ARCH}_release/libeay32.lib)
   set(OPENSSL_DEBUG_LIBRARIES ${CMAKE_SOURCE_DIR}/dep/lib/${DEP_ARCH}_debug/libeay32.lib)
+  set(ZLIB_INCLUDE_DIRS ${CMAKE_SOURCE_DIR}/dep/zlib)
+  set(ZLIB_LIBRARIES z)
+  set(BZIP2_INCLUDE_DIRS ${CMAKE_SOURCE_DIR}/dep/src/bzip2)
+  set(BZIP2_LIBRARIES bzip2)
   # zlib is build
 endif()
 
@@ -199,6 +203,9 @@ if(UNIX)
   find_package(MySQL REQUIRED)
   find_package(OpenSSL REQUIRED)
   find_package(ZLIB REQUIRED)
+  if(USE_EXTRACTORS)
+    find_package(BZip2 REQUIRED)
+  endif()
 endif()
 
 # Add uninstall script and target

--- a/contrib/extractor/CMakeLists.txt
+++ b/contrib/extractor/CMakeLists.txt
@@ -17,8 +17,8 @@
 cmake_minimum_required (VERSION 2.6)
 project (MANGOS_MAP_EXTRACTOR)
 
-include_directories (../../dep)
+include_directories(${CMAKE_SOURCE_DIR}/dep)
 
-add_executable (ad dbcfile.cpp System.cpp)
+add_executable(ad dbcfile.cpp System.cpp)
 
-target_link_libraries (ad loadlib)
+target_link_libraries(ad loadlib ${BZIP2_LIBRARIES} ${ZLIB_LIBRARIES})

--- a/contrib/extractor/System.cpp
+++ b/contrib/extractor/System.cpp
@@ -30,7 +30,7 @@
 #endif
 
 #include "dbcfile.h"
-#include <libmpq\mpq_libmpq.h>
+#include <libmpq/mpq_libmpq.h>
 
 #include "loadlib/adt.h"
 #include "loadlib/wdt.h"

--- a/contrib/extractor/dbcfile.cpp
+++ b/contrib/extractor/dbcfile.cpp
@@ -19,7 +19,7 @@
 #define _CRT_SECURE_NO_DEPRECATE
 
 #include "dbcfile.h"
-#include <libmpq\mpq_libmpq.h>
+#include <libmpq/mpq_libmpq.h>
 
 DBCFile::DBCFile(const std::string& filename):
     filename(filename),

--- a/contrib/mmap/CMakeLists.txt
+++ b/contrib/mmap/CMakeLists.txt
@@ -12,54 +12,60 @@ cmake_minimum_required (VERSION 2.6)
 
 message ("Mmap extractor included")
 
-project( MoveMapGen )
+project(MoveMapGen)
 
 ADD_DEFINITIONS(-DMMAP_GENERATOR -DNO_CORE_FUNCS -DDEBUG)
 
 # zlib
-ADD_DEFINITIONS( -DNO_vsnprintf )
+ADD_DEFINITIONS(-DNO_vsnprintf)
 
 if(!WIN32)
-	ADD_DEFINITIONS("-ggdb")
-	ADD_DEFINITIONS("-O3")
+    ADD_DEFINITIONS("-ggdb")
+    ADD_DEFINITIONS("-O3")
 endif()
 
 include_directories(
-    ../../src
-    ../../src/shared
-    ../../src/game
-    ../../src/game/vmap
-    ../../dep/include/g3dlite
-    ../../src/framework
-    ../../dep/ACE_wrappers
-    ../../objdir/dep/ACE_wrappers
-    ../../dep/recastnavigation/Detour/Include
-    ../../dep/recastnavigation/Recast/Include
-    ../../dep/src/zlib
+    ${CMAKE_SOURCE_DIR}/src
+    ${CMAKE_SOURCE_DIR}/src/shared
+    ${CMAKE_SOURCE_DIR}/src/game
+    ${CMAKE_SOURCE_DIR}/src/game/vmap
+    ${CMAKE_SOURCE_DIR}/dep/include/g3dlite
+    ${CMAKE_SOURCE_DIR}/src/framework
+    ${CMAKE_SOURCE_DIR}/dep/ACE_wrappers
+    ${CMAKE_SOURCE_DIR}/objdir/dep/ACE_wrappers
+    ${CMAKE_SOURCE_DIR}/dep/recastnavigation/Detour/Include
+    ${CMAKE_SOURCE_DIR}/dep/recastnavigation/Recast/Include
+    ${ZLIB_INCLUDE_DIRS}
 )
 
 
 add_library(vmap
-	../../src/game/vmap/BIH.cpp
-	../../src/game/vmap/VMapManager2.cpp
-	../../src/game/vmap/MapTree.cpp
-	../../src/game/vmap/TileAssembler.cpp
-	../../src/game/vmap/WorldModel.cpp
-	../../src/game/vmap/ModelInstance.cpp
+    ${CMAKE_SOURCE_DIR}/src/game/vmap/BIH.cpp
+    ${CMAKE_SOURCE_DIR}/src/game/vmap/VMapManager2.cpp
+    ${CMAKE_SOURCE_DIR}/src/game/vmap/MapTree.cpp
+    ${CMAKE_SOURCE_DIR}/src/game/vmap/TileAssembler.cpp
+    ${CMAKE_SOURCE_DIR}/src/game/vmap/WorldModel.cpp
+    ${CMAKE_SOURCE_DIR}/src/game/vmap/ModelInstance.cpp
 )
 
-target_link_libraries(vmap g3dlite zlib)
+if(UNIX)
+    target_link_libraries(vmap g3dlite ${ZLIB_LIBRARIES} pthread)
+else()
+    target_link_libraries(vmap g3dlite ${ZLIB_LIBRARIES})
+endif()
+
+target_link_libraries(vmap g3dlite ${ZLIB_LIBRARIES})
 
 add_library(Recast
-    ../../dep/recastnavigation/Recast/Source/Recast.cpp
-    ../../dep/recastnavigation/Recast/Source/RecastAlloc.cpp
-    ../../dep/recastnavigation/Recast/Source/RecastArea.cpp
-    ../../dep/recastnavigation/Recast/Source/RecastContour.cpp
-    ../../dep/recastnavigation/Recast/Source/RecastFilter.cpp
-    ../../dep/recastnavigation/Recast/Source/RecastMesh.cpp
-    ../../dep/recastnavigation/Recast/Source/RecastMeshDetail.cpp
-    ../../dep/recastnavigation/Recast/Source/RecastRasterization.cpp
-    ../../dep/recastnavigation/Recast/Source/RecastRegion.cpp
+    ${CMAKE_SOURCE_DIR}/dep/recastnavigation/Recast/Source/Recast.cpp
+    ${CMAKE_SOURCE_DIR}/dep/recastnavigation/Recast/Source/RecastAlloc.cpp
+    ${CMAKE_SOURCE_DIR}/dep/recastnavigation/Recast/Source/RecastArea.cpp
+    ${CMAKE_SOURCE_DIR}/dep/recastnavigation/Recast/Source/RecastContour.cpp
+    ${CMAKE_SOURCE_DIR}/dep/recastnavigation/Recast/Source/RecastFilter.cpp
+    ${CMAKE_SOURCE_DIR}/dep/recastnavigation/Recast/Source/RecastMesh.cpp
+    ${CMAKE_SOURCE_DIR}/dep/recastnavigation/Recast/Source/RecastMeshDetail.cpp
+    ${CMAKE_SOURCE_DIR}/dep/recastnavigation/Recast/Source/RecastRasterization.cpp
+    ${CMAKE_SOURCE_DIR}/dep/recastnavigation/Recast/Source/RecastRegion.cpp
 )
 
 set(SOURCES
@@ -70,6 +76,6 @@ set(SOURCES
     ./src/VMapExtensions.cpp
 )
 
-add_executable( MoveMapGen ${SOURCES} )
+add_executable(MoveMapGen ${SOURCES})
 
-target_link_libraries( MoveMapGen g3dlite vmap Recast detour zlib ${ACE_LIBRARIES} )
+target_link_libraries(MoveMapGen g3dlite vmap Recast detour ${ACE_LIBRARIES} ${ZLIB_LIBRARIES})

--- a/contrib/vmap_extractor/CMakeLists.txt
+++ b/contrib/vmap_extractor/CMakeLists.txt
@@ -17,7 +17,7 @@
 cmake_minimum_required (VERSION 2.6)
 project (MANGOS_VMAP_EXTRACT_IO)
 
-include_directories (../../dep)
+include_directories (${CMAKE_SOURCE_DIR}/dep)
 
 if(!WIN32)
 # uncomment next line to disable debug mode

--- a/contrib/vmap_extractor/vmapextract/CMakeLists.txt
+++ b/contrib/vmap_extractor/vmapextract/CMakeLists.txt
@@ -18,4 +18,4 @@ cmake_minimum_required (VERSION 2.6)
 project (MANGOS_IOMAP_EXTRACTOR)
 
 add_executable(vmapextractor adtfile.cpp  dbcfile.cpp gameobject_extract.cpp model.cpp  vmapexport.cpp  wdtfile.cpp  wmo.cpp)
-target_link_libraries(vmapextractor libmpq bzip2 zlib)
+target_link_libraries(vmapextractor libmpq ${BZIP2_LIBRARIES} ${ZLIB_LIBRARIES})

--- a/contrib/vmap_extractor/vmapextract/adtfile.h
+++ b/contrib/vmap_extractor/vmapextract/adtfile.h
@@ -19,7 +19,7 @@
 #ifndef ADT_H
 #define ADT_H
 
-#include <libmpq\mpq_libmpq.h>
+#include <libmpq/mpq_libmpq.h>
 #include "wmo.h"
 #include "vmapexport.h"
 #include "model.h"

--- a/contrib/vmap_extractor/vmapextract/dbcfile.cpp
+++ b/contrib/vmap_extractor/vmapextract/dbcfile.cpp
@@ -17,7 +17,7 @@
  */
 
 #include "dbcfile.h"
-#include <libmpq\mpq_libmpq.h>
+#include <libmpq/mpq_libmpq.h>
 #undef min
 #undef max
 

--- a/contrib/vmap_extractor/vmapextract/model.cpp
+++ b/contrib/vmap_extractor/vmapextract/model.cpp
@@ -20,8 +20,8 @@
 #include "model.h"
 #include "wmo.h"
 #include "matrix.h"
-#include <loadlib\loadlib.h>
-#include <libmpq\mpq_libmpq.h>
+#include <loadlib/loadlib.h>
+#include <libmpq/mpq_libmpq.h>
 
 Model::Model(std::string& filename) : filename(filename), vertices(0), indices(0)
 {

--- a/contrib/vmap_extractor/vmapextract/vmapexport.cpp
+++ b/contrib/vmap_extractor/vmapextract/vmapexport.cpp
@@ -45,7 +45,7 @@
 #include "wdtfile.h"
 #include "dbcfile.h"
 #include "wmo.h"
-#include <libmpq\mpq_libmpq.h>
+#include <libmpq/mpq_libmpq.h>
 
 #include "vmapexport.h"
 

--- a/contrib/vmap_extractor/vmapextract/wdtfile.h
+++ b/contrib/vmap_extractor/vmapextract/wdtfile.h
@@ -19,7 +19,7 @@
 #ifndef WDTFILE_H
 #define WDTFILE_H
 
-#include <libmpq\mpq_libmpq.h>
+#include <libmpq/mpq_libmpq.h>
 #include "wmo.h"
 #include <string>
 #include "stdlib.h"

--- a/contrib/vmap_extractor/vmapextract/wmo.cpp
+++ b/contrib/vmap_extractor/vmapextract/wmo.cpp
@@ -27,7 +27,7 @@
 #include <fstream>
 #undef min
 #undef max
-#include <libmpq\mpq_libmpq.h>
+#include <libmpq/mpq_libmpq.h>
 #include "adtfile.h" // for fixnamen
 
 using namespace std;

--- a/dep/libmpq/CMakeLists.txt
+++ b/dep/libmpq/CMakeLists.txt
@@ -14,7 +14,7 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
-add_library (libmpq mpq_libmpq.cpp libmpq/common.cpp libmpq/explode.cpp libmpq/extract.cpp libmpq/huffman.cpp libmpq/mpq.cpp libmpq/parser.cpp libmpq/wave.cpp )
+add_library(libmpq mpq_libmpq.cpp libmpq/common.cpp libmpq/explode.cpp libmpq/extract.cpp libmpq/huffman.cpp libmpq/mpq.cpp libmpq/parser.cpp libmpq/wave.cpp)
 
 include_directories(
   ${CMAKE_CURRENT_SOURCE_DIR}
@@ -23,7 +23,5 @@ include_directories(
 )
 
 if(WIN32)
-  target_link_libraries(libmpq loadlib
-    zlib
-  )
+  target_link_libraries(libmpq loadlib ${ZLIB_LIBRARIES})
 endif()

--- a/dep/loadlib/CMakeLists.txt
+++ b/dep/loadlib/CMakeLists.txt
@@ -23,4 +23,4 @@ include_directories(
 )
 
 # link loadlib with zlib
-target_link_libraries (loadlib zlib libmpq)
+target_link_libraries (loadlib libmpq ${ZLIB_LIBRARIES})

--- a/dep/src/g3dlite/CMakeLists.txt
+++ b/dep/src/g3dlite/CMakeLists.txt
@@ -66,12 +66,8 @@ include_directories(
   ${CMAKE_SOURCE_DIR}/dep/include/zlib
 )
 
-add_library(g3dlite STATIC
-  ${g3dlite_SRCS}
-)
+add_library(g3dlite STATIC ${g3dlite_SRCS})
 
 if(WIN32)
-  target_link_libraries(g3dlite
-    zlib
-  )
+  target_link_libraries(g3dlite ${ZLIB_LIBRARIES})
 endif()

--- a/src/game/Maps/MoveMapSharedDefines.h
+++ b/src/game/Maps/MoveMapSharedDefines.h
@@ -20,7 +20,7 @@
 #define _MOVE_MAP_SHARED_DEFINES_H
 
 #include "Platform/Define.h"
-#include "../recastnavigation/Detour/Include/DetourNavMesh.h"
+#include "../../dep/recastnavigation/Detour/Include/DetourNavMesh.h"
 
 #define MMAP_MAGIC 0x4d4d4150   // 'MMAP'
 #define MMAP_VERSION 3


### PR DESCRIPTION
- Changed backslashes in include paths to forward slashes, fixes compilation on GNU/Linux
- Refactored CMake build system to use paths relative to ${CMAKE_SOURCE_DIR} where possible, instead of paths relative to current
directory
- Fixed pthread linking error in MoveMapGen
- Fixed zlib linking error on GNU/Linux for all tools
- Fixed DetourNavMesh.h not found in MoveMapSharedDefines.h

Please remember not to use backslashes ('\') in include paths, they only work on Windows. Forward slashes ('/') should be used as
directory delimiters.