### PR TITLE
Implemented DetailsEmote handling for quests

### DIFF
--- a/src/game/GossipDef.cpp
+++ b/src/game/GossipDef.cpp
@@ -536,6 +536,14 @@ void PlayerMenu::SendQuestGiverQuestDetails(Quest const *pQuest, ObjectGuid npcG
     */
     GetMenuSession()->SendPacket(&data);
 
+    // The DetailsEmote is not part of this packet in vanilla.
+    // We have to send it separately with a delayed event.
+    for (uint32 i = 0; i < QUEST_EMOTE_COUNT; ++i)
+    {
+        if (pQuest->DetailsEmote[i] > 0)
+            GetMenuSession()->GetPlayer()->AddDelayedEmote(pQuest->DetailsEmote[i], ObjectGuid(npcGUID), pQuest->DetailsEmoteDelay[i]);
+    }
+
     DEBUG_LOG("WORLD: Sent SMSG_QUESTGIVER_QUEST_DETAILS NPCGuid = %s, questid = %u", npcGUID.GetString().c_str(), pQuest->GetQuestId());
 }
 

--- a/src/game/Objects/Player.cpp
+++ b/src/game/Objects/Player.cpp
@@ -16235,6 +16235,34 @@ void Player::TextEmote(const std::string& text)
     SendMessageToSetInRange(&data, sWorld.getConfig(CONFIG_FLOAT_LISTEN_RANGE_TEXTEMOTE), true, !sWorld.getConfig(CONFIG_BOOL_ALLOW_TWO_SIDE_INTERACTION_CHAT));
 }
 
+void Player::AddDelayedEmote(uint32 emote_id, ObjectGuid npc_guid, uint32 timeMSToEmote)
+{
+    if ((emote_id > 0) && npc_guid && npc_guid.IsUnit())
+    {
+        if (timeMSToEmote > 0)
+        {
+            EmoteDelayEvent *pEvent = new EmoteDelayEvent(*this, emote_id, npc_guid);
+            m_Events.AddEvent(pEvent, m_Events.CalculateTime(timeMSToEmote));
+        }
+        else
+        {
+            WorldPacket data(SMSG_EMOTE, 4 + 8);
+            data << uint32(emote_id);
+            data << npc_guid;
+            GetSession()->SendPacket(&data);
+        }
+    }
+}
+
+bool EmoteDelayEvent::Execute(uint64 /*e_time*/, uint32 /*p_time*/)
+{
+    WorldPacket data(SMSG_EMOTE, 4 + 8);
+    data << uint32(m_emote_id);
+    data << m_npc_guid;
+    m_owner.GetSession()->SendPacket(&data);
+    return true;
+}
+
 void Player::PetSpellInitialize()
 {
     Pet* pet = GetPet();

--- a/src/game/Objects/Player.h
+++ b/src/game/Objects/Player.h
@@ -1184,6 +1184,7 @@ class MANGOS_DLL_SPEC Player final: public Unit
         void PrepareGossipMenu(WorldObject *pSource, uint32 menuId = 0);
         void SendPreparedGossip(WorldObject *pSource);
         void OnGossipSelect(WorldObject *pSource, uint32 gossipListId);
+        void AddDelayedEmote(uint32 emote_id, ObjectGuid npc_guid, uint32 timeMSToEmote);
 
         uint32 GetGossipTextId(uint32 menuId, WorldObject const* source);
         uint32 GetGossipTextId(WorldObject *pSource);
@@ -2487,5 +2488,17 @@ template <class T> T Player::ApplySpellMod(uint32 spellId, SpellModOp op, T &bas
     basevalue = T((float)basevalue + diff);
     return T(diff);
 }
+
+class EmoteDelayEvent : public BasicEvent
+{
+public:
+    explicit EmoteDelayEvent(Player& owner, uint32 emote_id, ObjectGuid npc_guid) : BasicEvent(), m_owner(owner), m_emote_id(emote_id), m_npc_guid(npc_guid) { }
+    bool Execute(uint64 e_time, uint32 p_time) override;
+
+private:
+    Player& m_owner;
+    uint32 m_emote_id;
+    ObjectGuid m_npc_guid;
+};
 
 #endif


### PR DESCRIPTION
I noticed that the DetailsEmote on quests wasn't being displayed at all. That's the emote when the quest is being offered to you. So i looked into the code, and it turns out that it wasn't being sent at all. Apparently it's either not part of the SMSG_QUESTGIVER_QUEST_DETAILS packet, or the packet structure is not the same as in wotlk, and nobody bothered to figure out where the emote fits in vanilla. I came up with a simple workaround to send the emote to the player using a delayed event.

See the gif if you don't get what I'm talking about.
![ezgif-1-34a527cd98](https://cloud.githubusercontent.com/assets/6519171/26800773/21ca81b2-4a43-11e7-81d0-449df6c871f2.gif)
