### PR TITLE
Don't show incomplete text for completed quests

### DIFF
--- a/src/game/GossipDef.cpp
+++ b/src/game/GossipDef.cpp
@@ -736,8 +736,11 @@ void PlayerMenu::SendQuestGiverRequestItems(Quest const *pQuest, ObjectGuid npcG
         }
     }
 
-    // We may wish a better check, perhaps checking the real quest requirements
-    if (RequestItemsText.empty())
+    // Quests that don't require items use the RequestItemsText field to store the text
+    // that is shown when you talk to the quest giver while the quest is incomplete.
+    // Therefore the text should not be shown for them when the quest is complete.
+    // For quests that do require items, it is self explanatory.
+    if (RequestItemsText.empty() || (!pQuest->HasItemsRequirement() && Completable))
     {
         SendQuestGiverOfferReward(pQuest, npcGUID, true);
         return;

--- a/src/game/QuestDef.h
+++ b/src/game/QuestDef.h
@@ -213,6 +213,7 @@ class Quest
         bool HasQuestFlag(QuestFlags flag) const { return (m_QuestFlags & flag) != 0; }
         bool HasSpecialFlag(QuestSpecialFlags flag) const { return (m_SpecialFlags & flag) != 0; }
         void SetSpecialFlag(QuestSpecialFlags flag) { m_SpecialFlags |= flag; }
+        bool HasItemsRequirement() const { return (ReqItemId[0] || ReqItemId[1] || ReqItemId[2] || ReqItemId[03]); }
 
         // table data accessors:
         uint32 GetQuestId() const { return QuestId; }


### PR DESCRIPTION
I was working on fixing quest emotes in the starting zones, so i was watching old let's plays and i noticed that on Elysium the text that is supposed to be shown only when the quest is incomplete, is shown for completed quests too. So i looked into it and it turns out that the "RequestItemsText" field is used for two different things.

Obviously like its name implies, it is used to hold the text that is displayed when a quest requires certain items, but for quests that don't have an item requirement, it holds the incomplete quest text. That text is not supposed to be shown if the quest is complete, as is obvious from every old retail let's play video. There was even a comment in the code, indicating that there should probably be a check if the quest has any item requirements before showing it.