### PR TITLE
Fix Some Quest-Starting Items not Being Returned on Abandon

### DIFF
--- a/sql/migrations/20170608143646_world.sql
+++ b/sql/migrations/20170608143646_world.sql
@@ -1,0 +1,30 @@
+INSERT INTO `migrations` VALUES ('20170608143646');
+
+-- Update quests that are started by a quest, but don't have the quest-starting item listed.
+
+-- Captain Sander's Hidden Treasure
+UPDATE `quest_template` SET `SrcItemId` = 1357 WHERE `entry` = 136;
+-- Message in a Bottle
+UPDATE `quest_template` SET `SrcItemId` = 4098 WHERE `entry` = 594;
+-- Cortello's Riddle
+UPDATE `quest_template` SET `SrcItemId` = 4056 WHERE `entry` = 624;
+-- Tanaris Field Sampling
+UPDATE `quest_template` SET `SrcItemId` = 8524 WHERE `entry` = 654;
+-- The Tome of Divinity (Stormwind)
+UPDATE `quest_template` SET `SrcItemId` = 6775 WHERE `entry` = 1642;
+-- The Tome of Divinity (Ironforge)
+UPDATE `quest_template` SET `SrcItemId` = 6916 WHERE `entry` = 1646;
+-- The Tome of Valor
+UPDATE `quest_template` SET `SrcItemId` = 6776 WHERE `entry` = 1649;
+-- Cuergo's Gold
+UPDATE `quest_template` SET `SrcItemId` = 9245 WHERE `entry` = 2882;
+-- Glyphic Rune
+UPDATE `quest_template` SET `SrcItemId` = 9572  WHERE `entry` = 3111;
+-- Assassination Plot
+UPDATE `quest_template` SET `SrcItemId` = 12564 WHERE `entry` = 4881;
+-- Warlord's Command
+UPDATE `quest_template` SET `SrcItemId` = 12562 WHERE `entry` = 4903;
+-- Ammo for Rumbleshot
+UPDATE `quest_template` SET `SrcItemId` = 13850 WHERE `entry` = 5541;
+-- Blackhand's Command
+UPDATE `quest_template` SET `SrcItemId` = 18987 WHERE `entry` = 7761;

--- a/src/game/Commands/Level3.cpp
+++ b/src/game/Commands/Level3.cpp
@@ -4593,7 +4593,7 @@ bool ChatHandler::HandleQuestRemoveCommand(char* args)
             player->SetQuestSlot(slot, 0);
 
             // we ignore unequippable quest items in this case, its' still be equipped
-            player->TakeQuestSourceItem(quest, false);
+            player->TakeOrReplaceQuestStartItems(quest, false, true);
         }
     }
 
@@ -7620,7 +7620,7 @@ bool ChatHandler::HandleDebugShowNearestGOInfo(char* args)
             float PlayerPosZ = 0.0f;
             pl->GetPosition(PlayerPosX, PlayerPosY, PlayerPosZ);
 
-            
+
         }
         else
         {

--- a/src/game/Database/SQLStorages.cpp
+++ b/src/game/Database/SQLStorages.cpp
@@ -55,3 +55,6 @@ SQLStorage sConditionStorage(ConditionsSrcFmt, ConditionsDstFmt, "condition_entr
 SQLStorage sAreaStorage(AreaEntryfmt, "entry", "area_template");
 
 SQLHashStorage sGOStorage(GameObjectInfosrcfmt, GameObjectInfodstfmt, "entry", "gameobject_template");
+
+// Map certain quests to their quest start items. quest_id->item_id
+std::unordered_map<uint32, uint32> sQuestStartItems;

--- a/src/game/Database/SQLStorages.cpp
+++ b/src/game/Database/SQLStorages.cpp
@@ -55,6 +55,3 @@ SQLStorage sConditionStorage(ConditionsSrcFmt, ConditionsDstFmt, "condition_entr
 SQLStorage sAreaStorage(AreaEntryfmt, "entry", "area_template");
 
 SQLHashStorage sGOStorage(GameObjectInfosrcfmt, GameObjectInfodstfmt, "entry", "gameobject_template");
-
-// Map certain quests to their quest start items. quest_id->item_id
-std::unordered_map<uint32, uint32> sQuestStartItems;

--- a/src/game/Database/SQLStorages.h
+++ b/src/game/Database/SQLStorages.h
@@ -39,5 +39,7 @@ extern SQLStorage sAreaStorage;
 
 extern SQLHashStorage sGOStorage;
 
+// Map certain quests to their quest start items. quest_id->item_id
+extern std::unordered_map<uint32, uint32> sQuestStartItems;
 
 #endif

--- a/src/game/Database/SQLStorages.h
+++ b/src/game/Database/SQLStorages.h
@@ -39,7 +39,4 @@ extern SQLStorage sAreaStorage;
 
 extern SQLHashStorage sGOStorage;
 
-// Map certain quests to their quest start items. quest_id->item_id
-extern std::unordered_map<uint32, uint32> sQuestStartItems;
-
 #endif

--- a/src/game/Handlers/QuestHandler.cpp
+++ b/src/game/Handlers/QuestHandler.cpp
@@ -350,8 +350,9 @@ void WorldSession::HandleQuestLogRemoveQuest(WorldPacket& recv_data)
     {
         if (uint32 quest = _player->GetQuestSlotQuestId(slot))
         {
-            if (!_player->TakeQuestSourceItem(quest, true))
-                return;                                     // can't un-equip some items, reject quest cancel
+            if (!_player->TakeOrReplaceQuestStartItems(quest, true, true))
+            // can't un-equip some items, reject quest cancel
+                return;
 
             if (const Quest *pQuest = sObjectMgr.GetQuestTemplate(quest))
             {

--- a/src/game/ObjectMgr.cpp
+++ b/src/game/ObjectMgr.cpp
@@ -2165,12 +2165,11 @@ void ObjectMgr::LoadItemPrototypes()
         }
 
 
-        if (proto->StartQuest >= 0)
+        if (proto->StartQuest > 0)
         // Item starts a quest, insert it into the quest->startItem map
         {
             if (sQuestStartItems.find(proto->StartQuest) == sQuestStartItems.end())
                 sQuestStartItems.insert( std::pair<uint32, uint32>(proto->StartQuest, proto->ItemId) );
-
             else
                 sLog.outErrorDb("Item #%u also starts quest #%u.", i, proto->StartQuest);
         }

--- a/src/game/ObjectMgr.cpp
+++ b/src/game/ObjectMgr.cpp
@@ -2163,6 +2163,17 @@ void ObjectMgr::LoadItemPrototypes()
                 }
             }
         }
+
+
+        if (proto->StartQuest >= 0)
+        // Item starts a quest, insert it into the quest->startItem map
+        {
+            if (sQuestStartItems.find(proto->StartQuest) == sQuestStartItems.end())
+                sQuestStartItems.insert( std::pair<uint32, uint32>(proto->StartQuest, proto->ItemId) );
+
+            else
+                sLog.outErrorDb("Item #%u also starts quest #%u.", i, proto->StartQuest);
+        }
     }
 
     // check some dbc referenced items (avoid duplicate reports)

--- a/src/game/ObjectMgr.cpp
+++ b/src/game/ObjectMgr.cpp
@@ -1904,6 +1904,7 @@ void ObjectMgr::LoadItemPrototypes()
 {
     SQLItemLoader loader;
     loader.Load(sItemStorage);
+    mQuestStartingItems.clear();
     sLog.outString(">> Loaded %u item prototypes", sItemStorage.GetRecordCount());
     sLog.outString();
 
@@ -2168,8 +2169,8 @@ void ObjectMgr::LoadItemPrototypes()
         if (proto->StartQuest > 0)
         // Item starts a quest, insert it into the quest->startItem map
         {
-            if (sQuestStartItems.find(proto->StartQuest) == sQuestStartItems.end())
-                sQuestStartItems.insert( std::pair<uint32, uint32>(proto->StartQuest, proto->ItemId) );
+            if (mQuestStartingItems.find(proto->StartQuest) == mQuestStartingItems.end())
+                mQuestStartingItems.insert( std::pair<uint32, uint32>(proto->StartQuest, proto->ItemId) );
             else
                 sLog.outErrorDb("Item #%u also starts quest #%u.", i, proto->StartQuest);
         }
@@ -3885,6 +3886,16 @@ void ObjectMgr::LoadQuests()
 
     sLog.outString();
     sLog.outString(">> Loaded %lu quests definitions", (unsigned long)mQuestTemplates.size());
+}
+
+uint32 ObjectMgr::GetQuestStartingItemID(uint32 quest_id) const
+{
+    auto questItemPair = mQuestStartingItems.find(quest_id);
+
+    if (questItemPair != mQuestStartingItems.end())
+        return questItemPair->second;
+
+    return 0;
 }
 
 void ObjectMgr::LoadQuestLocales()

--- a/src/game/ObjectMgr.h
+++ b/src/game/ObjectMgr.h
@@ -643,6 +643,10 @@ class ObjectMgr
         }
         QuestMap const& GetQuestTemplates() const { return mQuestTemplates; }
 
+        // Return the ID of the item that starts a quest.
+        // Return 0 if no such item exists.
+        uint32 GetQuestStartingItemID(uint32 quest_id) const;
+
         uint32 GetQuestForAreaTrigger(uint32 Trigger_ID) const
         {
             auto itr = mQuestAreaTriggerMap.find(Trigger_ID);
@@ -1234,6 +1238,8 @@ class ObjectMgr
         typedef UNORDERED_MAP<uint32, GossipText> GossipTextMap;
         typedef UNORDERED_MAP<uint32, uint32> QuestAreaTriggerMap;
         typedef UNORDERED_MAP<uint32, std::string> ItemTextMap;
+        // Map quest_id->id of start item
+        typedef UNORDERED_MAP<uint32, uint32> QuestStartingItemMap;
         typedef std::set<uint32> TavernAreaTriggerSet;
         typedef std::set<uint32> GameObjectForQuestSet;
 
@@ -1246,6 +1252,7 @@ class ObjectMgr
         GameObjectForQuestSet mGameObjectForQuestSet;
         GossipTextMap       mGossipText;
         AreaTriggerMap      mAreaTriggers;
+        QuestStartingItemMap   mQuestStartingItems;
         BGEntranceTriggerMap mBGEntranceTriggers;
 
         RepRewardRateMap    m_RepRewardRateMap;

--- a/src/game/Objects/Player.cpp
+++ b/src/game/Objects/Player.cpp
@@ -13109,11 +13109,12 @@ bool Player::TakeOrReplaceQuestStartItems(uint32 quest_id, bool msg, bool giveQu
                     }
 
                     // Additional check to prevent possible unlimited gold
-                    if (HasItemCount(srcItemId, count, false))
+                    if (HasItemCount(srcItemId, count, true))
                     {
-                        // Start- and given item not the same, destroy or replace it.
+                        // Start- and given item not the same, destroy it.
                         DestroyItemCount(srcItemId, count, true, true);
-
+                        
+                        // Replace item, if requested
                         if (giveQuestStartItem)
                         {
                             // Check if quest start item is available

--- a/src/game/Objects/Player.h
+++ b/src/game/Objects/Player.h
@@ -763,7 +763,7 @@ class TradeData
 
         time_t GetLastModificationTime() const { return m_lastModificationTime; }
         void SetLastModificationTime(time_t t) { m_lastModificationTime = t; }
-		
+
 		time_t GetScamPreventionDelay() const { return m_scamPreventionDelay; }
 		void SetScamPreventionDelay(time_t t) { m_scamPreventionDelay = t; }
     public:                                                 // access functions
@@ -1229,7 +1229,7 @@ class MANGOS_DLL_SPEC Player final: public Unit
         bool SatisfyQuestPrevChain( Quest const* qInfo, bool msg ) const;
         bool CanGiveQuestSourceItemIfNeed( Quest const *pQuest, ItemPosCountVec* dest = NULL) const;
         void GiveQuestSourceItemIfNeed(Quest const *pQuest);
-        bool TakeQuestSourceItem( uint32 quest_id, bool msg );
+        bool TakeOrReplaceQuestStartItems( uint32 quest_id, bool msg, bool giveQuestStartItem );
         bool GetQuestRewardStatus( uint32 quest_id ) const;
         QuestStatus GetQuestStatus( uint32 quest_id ) const;
         void SetQuestStatus( uint32 quest_id, QuestStatus status );
@@ -1935,7 +1935,7 @@ class MANGOS_DLL_SPEC Player final: public Unit
         void SetClientControl(Unit* target, uint8 allowMove);
         void SetMover(Unit* target) { m_mover = target ? target : this; }
         Unit* GetMover() const { return m_mover; }
-        bool IsSelfMover() const { return m_mover == this; }// normal case for player not controlling other unit        
+        bool IsSelfMover() const { return m_mover == this; }// normal case for player not controlling other unit
         bool IsNextRelocationIgnored() const { return m_bNextRelocationsIgnored ? true : false; }
         void SetNextRelocationsIgnoredCount(uint32 count) { m_bNextRelocationsIgnored = count; }
         void DoIgnoreRelocation() { if (m_bNextRelocationsIgnored) --m_bNextRelocationsIgnored; }


### PR DESCRIPTION
Takes care of #812.
[Affected quests](https://hastebin.com/uteqixibem.scala).

Also fixes quest items not being deleted on faction or skill change.

Items [18565](http://db.vanillagaming.org/?item=18565) and [20483](http://db.vanillagaming.org/?item=20483) were found to link to invalid quests. They remain untouched.