### PR TITLE
Added several commands to ScriptMgr

### DIFF
--- a/src/game/Maps/Map.cpp
+++ b/src/game/Maps/Map.cpp
@@ -3703,26 +3703,9 @@ void Map::ScriptsProcess()
                     terminateResult = sObjectMgr.IsPlayerMeetToCondition(step.script->terminateCond.conditionId, player, player->GetMap(), second, CONDITION_FROM_DBSCRIPTS);
                 }
 
-                if (terminateResult && step.script->terminateCond.failQuest && player)
+                if (player && terminateResult && step.script->terminateCond.failQuest)
                 {
-                    if (Group* group = player->GetGroup())
-                    {
-                        for (GroupReference* groupRef = group->GetFirstMember(); groupRef != NULL; groupRef = groupRef->next())
-                        {
-                            Player* member = groupRef->getSource();
-                            if (member->GetQuestStatus(step.script->terminateCond.failQuest) == QUEST_STATUS_INCOMPLETE)
-                            {
-                                member->FailQuest(step.script->terminateCond.failQuest);
-                            }
-                        }
-                    }
-                    else
-                    {
-                        if (player->GetQuestStatus(step.script->terminateCond.failQuest) == QUEST_STATUS_INCOMPLETE)
-                        {
-                            player->FailQuest(step.script->terminateCond.failQuest);
-                        }
-                    }
+                    player->GroupEventFailHappens(step.script->terminateCond.failQuest);
                 }
                 if (terminateResult) // Terminate further steps of this script
                 {

--- a/src/game/Maps/Map.cpp
+++ b/src/game/Maps/Map.cpp
@@ -2969,24 +2969,50 @@ void Map::ScriptsProcess()
 
                 break;
             }
-            case SCRIPT_COMMAND_DESPAWN_SELF:
+            case SCRIPT_COMMAND_DESPAWN_CREATURE:
             {
-                if (!target && !source)
+                if (!source)
                 {
-                    sLog.outError("SCRIPT_COMMAND_DESPAWN_SELF (script id %u) call for NULL object.", step.script->id);
+                    sLog.outError("SCRIPT_COMMAND_DESPAWN_CREATURE (script id %u) call for NULL source.", step.script->id);
                     break;
                 }
 
-                // only creature
-                if ((!target || target->GetTypeId() != TYPEID_UNIT) && (!source || source->GetTypeId() != TYPEID_UNIT))
+                if (!source->isType(TYPEMASK_WORLDOBJECT))
                 {
-                    sLog.outError("SCRIPT_COMMAND_DESPAWN_SELF (script id %u) call for non-creature (TypeIdSource: %u)(TypeIdTarget: %u), skipping.", step.script->id, source ? source->GetTypeId() : 0, target ? target->GetTypeId() : 0);
+                    sLog.outError("SCRIPT_COMMAND_DESPAWN_CREATURE (script id %u) call for unsupported non-worldobject (TypeId: %u), skipping.", step.script->id, source->GetTypeId());
                     break;
                 }
 
-                Creature* pCreature = target && target->GetTypeId() == TYPEID_UNIT ? (Creature*)target : (Creature*)source;
+                WorldObject* pSource = (WorldObject*)source;
+                Creature* pOwner = NULL;
 
-                pCreature->ForcedDespawn(step.script->despawn.despawnDelay);
+                // No buddy defined, so try use source (or target if source is not creature)
+                if (!step.script->despawn.creatureEntry)
+                {
+                    if (pSource->GetTypeId() != TYPEID_UNIT)
+                    {
+                        // we can't be non-creature, so see if target is creature
+                        if (target && target->GetTypeId() == TYPEID_UNIT)
+                            pOwner = (Creature*)target;
+                    }
+                    else if (pSource->GetTypeId() == TYPEID_UNIT)
+                        pOwner = (Creature*)pSource;
+                }
+                else                                        // If step has a buddy entry defined, search for it
+                {
+                    MaNGOS::NearestCreatureEntryWithLiveStateInObjectRangeCheck u_check(*pSource, step.script->despawn.creatureEntry, true, step.script->despawn.searchRadius);
+                    MaNGOS::CreatureLastSearcher<MaNGOS::NearestCreatureEntryWithLiveStateInObjectRangeCheck> searcher(pOwner, u_check);
+
+                    Cell::VisitGridObjects(pSource, searcher, step.script->despawn.searchRadius);
+                }
+
+                if (!pOwner)
+                {
+                    sLog.outError("SCRIPT_COMMAND_DESPAWN_CREATURE (script id %u) call for non-creature (TypeIdSource: %u)(TypeIdTarget: %u), skipping.", step.script->id, source->GetTypeId(), target ? target->GetTypeId() : 0);
+                    break;
+                }
+
+                pOwner->ForcedDespawn(step.script->despawn.despawnDelay);
 
                 break;
             }
@@ -3534,6 +3560,378 @@ void Map::ScriptsProcess()
                     }
                 }
 
+                break;
+            }
+            case SCRIPT_COMMAND_SEND_TAXI_PATH:
+            {
+                Player* pPlayer;
+
+                if (target && target->IsPlayer())
+                    pPlayer = (Player*)target;
+                else if (source && source->IsPlayer())
+                    pPlayer = (Player*)source;
+                
+                // only Player
+                if (!pPlayer)
+                {
+                    sLog.outError("SCRIPT_COMMAND_SEND_TAXI_PATH (script id %u) call for non-player, skipping.", step.script->id);
+                    break;
+                }
+                
+                pPlayer->ActivateTaxiPathTo(step.script->sendTaxiPath.taxiPathId, 0, true);
+                break;
+            }
+            case SCRIPT_COMMAND_TERMINATE_SCRIPT:
+            {
+                bool result = false;
+                if (step.script->terminateScript.creatureEntry)
+                {
+                    WorldObject* pSearcher = source ? (WorldObject*) source : (WorldObject*) target;
+                    if (pSearcher->GetTypeId() == TYPEID_PLAYER && target && target->GetTypeId() != TYPEID_PLAYER)
+                    {
+                        pSearcher = (WorldObject*) target;
+                    }
+
+                    Creature* pCreatureBuddy = NULL;
+                    MaNGOS::NearestCreatureEntryWithLiveStateInObjectRangeCheck u_check(*pSearcher, step.script->terminateScript.creatureEntry, true, step.script->terminateScript.searchRadius);
+                    MaNGOS::CreatureLastSearcher<MaNGOS::NearestCreatureEntryWithLiveStateInObjectRangeCheck> searcher(pCreatureBuddy, u_check);
+                    Cell::VisitGridObjects(pSearcher, searcher, step.script->terminateScript.searchRadius);
+
+                    if (!(step.script->terminateScript.flags & 0x01) && !pCreatureBuddy)
+                        result = true; // when npc was not found alive
+                    else if (step.script->terminateScript.flags & 0x01 && pCreatureBuddy)
+                        result = true; // when npc was found alive
+                }
+                else
+                    result = true;
+
+                if (result) // Terminate further steps of this script
+                {
+                    uint32 id = iter->second.script->id;
+                    ObjectGuid sourceGuid = iter->second.sourceGuid;
+                    ObjectGuid targetGuid = iter->second.targetGuid;
+                    ObjectGuid ownerGuid = iter->second.ownerGuid;
+
+                    for (ScriptScheduleMap::iterator rmItr = m_scriptSchedule.begin(); rmItr != m_scriptSchedule.end();)
+                    {
+                        if (rmItr->second.IsSameScript(id, sourceGuid, targetGuid, ownerGuid))
+                        {
+                            m_scriptSchedule.erase(rmItr++);
+                            sScriptMgr.DecreaseScheduledScriptCount();
+                        }
+                        else
+                        {
+                            ++rmItr;
+                        }
+                    }
+                    return;
+                }
+
+                break;
+            }
+            case SCRIPT_COMMAND_ENTER_EVADE_MODE:
+            {
+                if (!source)
+                {
+                    sLog.outError("SCRIPT_COMMAND_ENTER_EVADE_MODE (script id %u) call for NULL source.", step.script->id);
+                    break;
+                }
+
+                if (!source->isType(TYPEMASK_WORLDOBJECT))
+                {
+                    sLog.outError("SCRIPT_COMMAND_ENTER_EVADE_MODE (script id %u) call for unsupported non-worldobject (TypeId: %u), skipping.", step.script->id, source->GetTypeId());
+                    break;
+                }
+
+                WorldObject* pSource = (WorldObject*)source;
+                Creature* pOwner = NULL;
+
+                // No buddy defined, so try use source (or target if source is not creature)
+                if (!step.script->enterEvadeMode.creatureEntry)
+                {
+                    if (pSource->GetTypeId() != TYPEID_UNIT)
+                    {
+                        // we can't be non-creature, so see if target is creature
+                        if (target && target->GetTypeId() == TYPEID_UNIT)
+                            pOwner = (Creature*)target;
+                    }
+                    else if (pSource->GetTypeId() == TYPEID_UNIT)
+                        pOwner = (Creature*)pSource;
+                }
+                else                                        // If step has a buddy entry defined, search for it
+                {
+                    MaNGOS::NearestCreatureEntryWithLiveStateInObjectRangeCheck u_check(*pSource, step.script->enterEvadeMode.creatureEntry, true, step.script->enterEvadeMode.searchRadius);
+                    MaNGOS::CreatureLastSearcher<MaNGOS::NearestCreatureEntryWithLiveStateInObjectRangeCheck> searcher(pOwner, u_check);
+
+                    Cell::VisitGridObjects(pSource, searcher, step.script->enterEvadeMode.searchRadius);
+                }
+
+                if (!pOwner)
+                {
+                    sLog.outError("SCRIPT_COMMAND_ENTER_EVADE_MODE (script id %u) call for non-creature (TypeIdSource: %u)(TypeIdTarget: %u), skipping.", step.script->id, source->GetTypeId(), target ? target->GetTypeId() : 0);
+                    break;
+                }
+
+                if (pOwner->AI())
+                    pOwner->AI()->EnterEvadeMode();
+
+                break;
+            }
+            case SCRIPT_COMMAND_TERMINATE_COND:
+            {
+                Player* player = NULL;
+                WorldObject* second = (WorldObject*) source;
+                // First case: target is player
+                if (target && target->GetTypeId() == TYPEID_PLAYER)
+                {
+                    player = static_cast<Player*>(target);
+                }
+                // Second case: source is player
+                else if (source && source->GetTypeId() == TYPEID_PLAYER)
+                {
+                    player = static_cast<Player*>(source);
+                    second = (WorldObject*) target;
+                }
+
+                bool terminateResult;
+                if (step.script->terminateCond.flags & 0x01)
+                {
+                    terminateResult = !sObjectMgr.IsPlayerMeetToCondition(step.script->terminateCond.conditionId, player, player->GetMap(), second, CONDITION_FROM_DBSCRIPTS);
+                }
+                else
+                {
+                    terminateResult = sObjectMgr.IsPlayerMeetToCondition(step.script->terminateCond.conditionId, player, player->GetMap(), second, CONDITION_FROM_DBSCRIPTS);
+                }
+
+                if (terminateResult && step.script->terminateCond.failQuest && player)
+                {
+                    if (Group* group = player->GetGroup())
+                    {
+                        for (GroupReference* groupRef = group->GetFirstMember(); groupRef != NULL; groupRef = groupRef->next())
+                        {
+                            Player* member = groupRef->getSource();
+                            if (member->GetQuestStatus(step.script->terminateCond.failQuest) == QUEST_STATUS_INCOMPLETE)
+                            {
+                                member->FailQuest(step.script->terminateCond.failQuest);
+                            }
+                        }
+                    }
+                    else
+                    {
+                        if (player->GetQuestStatus(step.script->terminateCond.failQuest) == QUEST_STATUS_INCOMPLETE)
+                        {
+                            player->FailQuest(step.script->terminateCond.failQuest);
+                        }
+                    }
+                }
+                if (terminateResult) // Terminate further steps of this script
+                {
+                    uint32 id = iter->second.script->id;
+                    ObjectGuid sourceGuid = iter->second.sourceGuid;
+                    ObjectGuid targetGuid = iter->second.targetGuid;
+                    ObjectGuid ownerGuid = iter->second.ownerGuid;
+
+                    for (ScriptScheduleMap::iterator rmItr = m_scriptSchedule.begin(); rmItr != m_scriptSchedule.end();)
+                    {
+                        if (rmItr->second.IsSameScript(id, sourceGuid, targetGuid, ownerGuid))
+                        {
+                            m_scriptSchedule.erase(rmItr++);
+                            sScriptMgr.DecreaseScheduledScriptCount();
+                        }
+                        else
+                        {
+                            ++rmItr;
+                        }
+                    }
+                    return;
+                }
+
+                break;
+            }
+            case SCRIPT_COMMAND_TURN_TO:
+            {
+                if (!source)
+                {
+                    sLog.outError("SCRIPT_COMMAND_TURN_TO (script id %u) call for NULL source.", step.script->id);
+                    break;
+                }
+
+                if (!source->isType(TYPEMASK_WORLDOBJECT))
+                {
+                    sLog.outError("SCRIPT_COMMAND_TURN_TO (script id %u) call for unsupported non-worldobject (TypeId: %u), skipping.", step.script->id, source->GetTypeId());
+                    break;
+                }
+
+                if (step.script->turnTo.facingLogic == 0)
+                {
+                    if (step.script->turnTo.isSourceTarget)
+                    {
+                        if (!step.script->turnTo.creatureEntry && target && (target->GetTypeId() == TYPEID_UNIT))
+                        {
+                            // the target (probably player) faces the source of the script
+                            Unit* pSource = target->ToUnit();
+
+                            WorldObject* pTarget = (WorldObject*)source;
+
+                            if (pSource && pTarget)
+                                pSource->SetFacingToObject(pTarget);
+                        }
+                        else if (target && (target->GetTypeId() == TYPEID_UNIT || target->GetTypeId() == TYPEID_PLAYER))
+                        {
+                            // the target (probably player) searches for a creature and faces it
+                            WorldObject* pSource = (WorldObject*)source;
+                            Creature* pTarget;
+                            Unit* originalTarget = target->ToUnit();
+
+                            MaNGOS::NearestCreatureEntryWithLiveStateInObjectRangeCheck u_check(*pSource, step.script->turnTo.creatureEntry, true, step.script->turnTo.searchRadius);
+                            MaNGOS::CreatureLastSearcher<MaNGOS::NearestCreatureEntryWithLiveStateInObjectRangeCheck> searcher(pTarget, u_check);
+
+                            Cell::VisitGridObjects(pSource, searcher, step.script->turnTo.searchRadius);
+
+                            if (pTarget && originalTarget)
+                                originalTarget->SetFacingToObject(pTarget);
+                        }
+                        else
+                        {
+                            sLog.outError("SCRIPT_COMMAND_TURN_TO (script id %u) call with datalong=0 and datalong2!=0 but script target is not Unit.", step.script->id);
+                            break;
+                        }
+                    }
+                    else
+                    {
+                        if (!step.script->turnTo.creatureEntry && (source->GetTypeId() == TYPEID_UNIT))
+                        {
+                            // unit that is the source of the script faces the target (probably player)
+                            Unit* pSource = source->ToUnit();
+                        
+                            WorldObject* pTarget;
+
+                            if (target && target->isType(TYPEMASK_WORLDOBJECT))
+                                pTarget = (WorldObject*) target;
+
+                            if (pTarget && pSource)
+                                pSource->SetFacingToObject(pTarget);
+                        }
+                        else if (step.script->turnTo.creatureEntry)
+                        {
+                            // unit that is the source of the script searches for a creature and faces it
+                            WorldObject* pSource = (WorldObject*)source;
+                            Creature* pTarget;
+                            WorldObject* originalTarget;
+                            if (target && target->isType(TYPEMASK_WORLDOBJECT))
+                                originalTarget = (WorldObject*)target;
+
+                            MaNGOS::NearestCreatureEntryWithLiveStateInObjectRangeCheck u_check(*pSource, step.script->turnTo.creatureEntry, true, step.script->turnTo.searchRadius);
+                            MaNGOS::CreatureLastSearcher<MaNGOS::NearestCreatureEntryWithLiveStateInObjectRangeCheck> searcher(pTarget, u_check);
+
+                            Cell::VisitGridObjects(pSource, searcher, step.script->turnTo.searchRadius);
+
+                            if (pTarget && originalTarget)
+                                pTarget->SetFacingToObject(originalTarget);
+                        }
+                        else
+                        {
+                            sLog.outError("SCRIPT_COMMAND_TURN_TO (script id %u) call with datalong=0 and datalong2=0 but script source is not Unit.", step.script->id);
+                            break;
+                        }
+                    }
+                }
+                else if (step.script->turnTo.facingLogic == 1)
+                {
+                    if (step.script->turnTo.creatureEntry)
+                    {
+                        // searching for a creature and setting its facing to the orientation specified
+                        WorldObject* pSource = (WorldObject*)source;
+                        Creature* pTarget;
+
+                        MaNGOS::NearestCreatureEntryWithLiveStateInObjectRangeCheck u_check(*pSource, step.script->turnTo.creatureEntry, true, step.script->turnTo.searchRadius);
+                        MaNGOS::CreatureLastSearcher<MaNGOS::NearestCreatureEntryWithLiveStateInObjectRangeCheck> searcher(pTarget, u_check);
+
+                        Cell::VisitGridObjects(pSource, searcher, step.script->turnTo.searchRadius);
+
+                        if (pTarget)
+                            pTarget->SetFacingTo(step.script->o);
+                    }
+                    else if (step.script->turnTo.isSourceTarget)
+                    {
+                        // setting target's (probably player) facing to the orientation specified
+                        if (target && (target->GetTypeId() == TYPEID_UNIT || target->GetTypeId() == TYPEID_PLAYER))
+                        {
+                            Unit* pTarget = target->ToUnit();
+
+                            if (pTarget)
+                                pTarget->SetFacingTo(step.script->o);
+                        }
+                        else
+                        {
+                            sLog.outError("SCRIPT_COMMAND_TURN_TO (script id %u) call with datalong=1 and datalong2!=0 but script target is not Unit.", step.script->id);
+                            break;
+                        }
+                    }
+                    else if (source->GetTypeId() == TYPEID_UNIT)
+                    {
+                        // setting the script source's facing to the orientation specified
+                        Unit* pSource = source->ToUnit();
+
+                        if (pSource)
+                            pSource->SetFacingTo(step.script->o);
+                    }
+                    else
+                    {
+                        sLog.outError("SCRIPT_COMMAND_TURN_TO (script id %u) call with datalong=1 and datalong2=0 but script source is not Unit.", step.script->id);
+                        break;
+                    }
+                    
+                }
+                else if (step.script->turnTo.facingLogic == 2)
+                {
+                    if (step.script->turnTo.creatureEntry)
+                    {
+                        if (step.script->turnTo.isSourceTarget)
+                        {
+                            // searches for a creature and makes it face the source of the script
+                            WorldObject* pSource = (WorldObject*)source;
+                            Creature* pTarget;
+
+                            MaNGOS::NearestCreatureEntryWithLiveStateInObjectRangeCheck u_check(*pSource, step.script->turnTo.creatureEntry, true, step.script->turnTo.searchRadius);
+                            MaNGOS::CreatureLastSearcher<MaNGOS::NearestCreatureEntryWithLiveStateInObjectRangeCheck> searcher(pTarget, u_check);
+
+                            Cell::VisitGridObjects(pSource, searcher, step.script->turnTo.searchRadius);
+
+                            if (pTarget)
+                                pTarget->SetFacingToObject(pSource);
+                        }
+                        else if (source->GetTypeId() == TYPEID_UNIT)
+                        {
+                            // searches for a creature and makes unit that is the source of the script face it
+                            Unit* pSource = source->ToUnit();
+                            Creature* pTarget;
+
+                            MaNGOS::NearestCreatureEntryWithLiveStateInObjectRangeCheck u_check(*pSource, step.script->turnTo.creatureEntry, true, step.script->turnTo.searchRadius);
+                            MaNGOS::CreatureLastSearcher<MaNGOS::NearestCreatureEntryWithLiveStateInObjectRangeCheck> searcher(pTarget, u_check);
+
+                            Cell::VisitGridObjects(pSource, searcher, step.script->turnTo.searchRadius);
+
+                            if (pTarget)
+                                pSource->SetFacingToObject(pTarget);
+                        }
+                        else
+                        {
+                            sLog.outError("SCRIPT_COMMAND_TURN_TO (script id %u) call with datalong=2 and datalong2=0 but script source is not Unit.", step.script->id);
+                            break;
+                        }
+                    }
+                    else
+                    {
+                        sLog.outError("SCRIPT_COMMAND_TURN_TO (script id %u) call with datalong=2 but no creature entry specified.", step.script->id);
+                        break;
+                    }
+                }
+                else
+                {
+                    sLog.outError("SCRIPT_COMMAND_TURN_TO (script id %u) unsupported call with value datalong=%i.", step.script->id, step.script->turnTo.facingLogic);
+                    break;
+                }
                 break;
             }
             default:

--- a/src/game/ScriptMgr.cpp
+++ b/src/game/ScriptMgr.cpp
@@ -639,12 +639,12 @@ void ScriptMgr::LoadScripts(ScriptMapMap& scripts, const char* tablename)
                 }
                 if (tmp.turnTo.creatureEntry && !ObjectMgr::GetCreatureTemplate(tmp.turnTo.creatureEntry))
                 {
-                    sLog.outErrorDb("Table `%s` has datalong3 = %u in SCRIPT_COMMAND_TERMINATE_SCRIPT for script id %u, but this npc entry does not exist.", tablename, tmp.turnTo.creatureEntry, tmp.id);
+                    sLog.outErrorDb("Table `%s` has datalong3 = %u in SCRIPT_COMMAND_TURN_TO for script id %u, but this npc entry does not exist.", tablename, tmp.turnTo.creatureEntry, tmp.id);
                     continue;
                 }
                 if (tmp.turnTo.creatureEntry && !tmp.turnTo.searchRadius)
                 {
-                    sLog.outErrorDb("Table `%s` has datalong3 = %u in  SCRIPT_COMMAND_TERMINATE_SCRIPT for script id %u, but search radius is too small (datalong4 = %u).", tablename, tmp.turnTo.creatureEntry, tmp.id, tmp.turnTo.searchRadius);
+                    sLog.outErrorDb("Table `%s` has datalong3 = %u in  SCRIPT_COMMAND_TURN_TO for script id %u, but search radius is too small (datalong4 = %u).", tablename, tmp.turnTo.creatureEntry, tmp.id, tmp.turnTo.searchRadius);
                     continue;
                 }
                 break;

--- a/src/game/ScriptMgr.cpp
+++ b/src/game/ScriptMgr.cpp
@@ -350,9 +350,18 @@ void ScriptMgr::LoadScripts(ScriptMapMap& scripts, const char* tablename)
                 }
                 break;
             }
-            case SCRIPT_COMMAND_DESPAWN_SELF:
+            case SCRIPT_COMMAND_DESPAWN_CREATURE:
             {
-                // for later, we might consider despawn by database guid, and define in datalong2 as option to despawn self.
+                if (tmp.despawn.creatureEntry && !ObjectMgr::GetCreatureTemplate(tmp.despawn.creatureEntry))
+                {
+                    sLog.outErrorDb("Table `%s` has datalong2 = %u in SCRIPT_COMMAND_DESPAWN_CREATURE for script id %u, but this creature_template does not exist.", tablename, tmp.despawn.creatureEntry, tmp.id);
+                    continue;
+                }
+                if (tmp.despawn.creatureEntry && !tmp.despawn.searchRadius)
+                {
+                    sLog.outErrorDb("Table `%s` has datalong2 = %u in SCRIPT_COMMAND_DESPAWN_CREATURE for script id %u, but search radius is too small (datalong3 = %u).", tablename, tmp.despawn.creatureEntry, tmp.id, tmp.despawn.searchRadius);
+                    continue;
+                }
                 break;
             }
             case SCRIPT_COMMAND_PLAY_MOVIE:
@@ -566,6 +575,76 @@ void ScriptMgr::LoadScripts(ScriptMapMap& scripts, const char* tablename)
                 if (tmp.npcFlag.creatureEntry && !tmp.npcFlag.searchRadius)
                 {
                     sLog.outErrorDb("Table `%s` has datalong3 = %u in SCRIPT_COMMAND_MODIFY_NPC_FLAGS for script id %u, but search radius is too small (datalong4 = %u).", tablename, tmp.npcFlag.creatureEntry, tmp.id, tmp.npcFlag.searchRadius);
+                    continue;
+                }
+                break;
+            }
+            case SCRIPT_COMMAND_SEND_TAXI_PATH:
+            {
+                if (!sTaxiPathStore.LookupEntry(tmp.sendTaxiPath.taxiPathId))
+                {
+                    sLog.outErrorDb("Table `%s` has datalong = %u in SCRIPT_COMMAND_SEND_TAXI_PATH for script id %u, but this taxi path does not exist.", tablename, tmp.sendTaxiPath.taxiPathId, tmp.id);
+                    continue;
+                }
+                break;
+            }
+            case SCRIPT_COMMAND_TERMINATE_SCRIPT:
+            {
+                if (tmp.terminateScript.creatureEntry && !ObjectMgr::GetCreatureTemplate(tmp.terminateScript.creatureEntry))
+                {
+                    sLog.outErrorDb("Table `%s` has datalong = %u in SCRIPT_COMMAND_TERMINATE_SCRIPT for script id %u, but this npc entry does not exist.", tablename, tmp.terminateScript.creatureEntry, tmp.id);
+                    continue;
+                }
+                if (tmp.terminateScript.creatureEntry && !tmp.terminateScript.searchRadius)
+                {
+                    sLog.outErrorDb("Table `%s` has datalong = %u in  SCRIPT_COMMAND_TERMINATE_SCRIPT for script id %u, but search radius is too small (datalong2 = %u).", tablename, tmp.terminateScript.creatureEntry, tmp.id, tmp.terminateScript.searchRadius);
+                    continue;
+                }
+                break;
+            }
+            case SCRIPT_COMMAND_ENTER_EVADE_MODE:
+            {
+                if (tmp.enterEvadeMode.creatureEntry && !ObjectMgr::GetCreatureTemplate(tmp.enterEvadeMode.creatureEntry))
+                {
+                    sLog.outErrorDb("Table `%s` has datalong = %u in SCRIPT_COMMAND_ENTER_EVADE_MODE for script id %u, but this creature_template does not exist.", tablename, tmp.enterEvadeMode.creatureEntry, tmp.id);
+                    continue;
+                }
+                if (tmp.enterEvadeMode.creatureEntry && !tmp.enterEvadeMode.searchRadius)
+                {
+                    sLog.outErrorDb("Table `%s` has datalong = %u in SCRIPT_COMMAND_ENTER_EVADE_MODE for script id %u, but search radius is too small (datalong2 = %u).", tablename, tmp.enterEvadeMode.creatureEntry, tmp.id, tmp.enterEvadeMode.searchRadius);
+                    continue;
+                }
+                break;
+            }
+            case SCRIPT_COMMAND_TERMINATE_COND:
+            {
+                if (!sConditionStorage.LookupEntry<PlayerCondition>(tmp.terminateCond.conditionId))
+                {
+                    sLog.outErrorDb("Table `%s` has datalong = %u in SCRIPT_COMMAND_TERMINATE_COND for script id %u, but this condition_id does not exist.", tablename, tmp.terminateCond.conditionId, tmp.id);
+                    continue;
+                }
+                if (tmp.terminateCond.failQuest && !sObjectMgr.GetQuestTemplate(tmp.terminateCond.failQuest))
+                {
+                    sLog.outErrorDb("Table `%s` has datalong2 = %u in SCRIPT_COMMAND_TERMINATE_COND for script id %u, but this questId does not exist.", tablename, tmp.terminateCond.failQuest, tmp.id);
+                    continue;
+                }
+                break;
+            }
+            case SCRIPT_COMMAND_TURN_TO:
+            {
+                if (tmp.turnTo.facingLogic > 2)
+                {
+                    sLog.outErrorDb("Table `%s` using unknown option in datalong (%u) in SCRIPT_COMMAND_TURN_TO for script id %u", tablename, tmp.turnTo.facingLogic, tmp.id);
+                    continue;
+                }
+                if (tmp.turnTo.creatureEntry && !ObjectMgr::GetCreatureTemplate(tmp.turnTo.creatureEntry))
+                {
+                    sLog.outErrorDb("Table `%s` has datalong3 = %u in SCRIPT_COMMAND_TERMINATE_SCRIPT for script id %u, but this npc entry does not exist.", tablename, tmp.turnTo.creatureEntry, tmp.id);
+                    continue;
+                }
+                if (tmp.turnTo.creatureEntry && !tmp.turnTo.searchRadius)
+                {
+                    sLog.outErrorDb("Table `%s` has datalong3 = %u in  SCRIPT_COMMAND_TERMINATE_SCRIPT for script id %u, but search radius is too small (datalong4 = %u).", tablename, tmp.turnTo.creatureEntry, tmp.id, tmp.turnTo.searchRadius);
                     continue;
                 }
                 break;


### PR DESCRIPTION
I implemented the following new commands in ScriptMgr, to allow for better database scripts:

- SCRIPT_COMMAND_SEND_TAXI_PATH (30)
_Puts the player on a flight path._
Variables:
datalong = taxi path id

- SCRIPT_COMMAND_TERMINATE_SCRIPT (31)
_Stops executing the script if a nearby npc is found. This can be used to prevent scripts from being started twice._
Variables:
datalong = npc entry to search for
datalong2 = search radius
data_flags = If its left at 0, stops the script if the creature is not found. If its set to 1, stops the script when the creature is found.

- SCRIPT_COMMAND_ENTER_EVADE_MODE (33)
_The creature enters evade mode, dropping combat and returning to its home position._
Variables:
datalong = npc entry to search for if you want it to evade instead of the source
datalong2 = search radius

- SCRIPT_COMMAND_TERMINATE_COND (34)
Stops executing the script if a condition from the `conditions` table is met.
Variables:
datalong = condition_id
datalong2 = quest_id if you want a quest to be failed
data_flags = set to 1 to stop script when condition it false, otherwise it stops when it's true.

- SCRIPT_COMMAND_TURN_TO (35)
_Changes an unit's orientation. You can make it face the player, face a nearby npc, or provide an orientation value and set it to that. The targets can be reversed, so for example you can have the npc you are searching for face the source instead of the other way around._
Variables:
datalong = 0 to face target (player), 1 to set to orientation specified, 2 to search for creature and face it
datalong2 = set to 1 to reverse targets
datalong3 = npc entry to search for
datalong4 = search radius
o = orientation value to be used if you have set datalong to 1

I also changed SCRIPT_COMMAND_DESPAWN_SELF to SCRIPT_COMMAND_DESPAWN_CREATURE to allow to search for a nearby creature and despawn it instead of the source.
