### PR TITLE
Fix NPC text in "Galen's Escape" quest

### DIFF
--- a/src/scripts/eastern_kingdoms/swamp_of_sorrows/swamp_of_sorrows.cpp
+++ b/src/scripts/eastern_kingdoms/swamp_of_sorrows/swamp_of_sorrows.cpp
@@ -37,13 +37,13 @@ enum Galen
 
     GO_GALENS_CAGE          = 37118,
 
-    SAY_PERIODIC            = -1000588,
-    SAY_QUEST_ACCEPTED      = -1000587,
-    SAY_ATTACKED_1          = -1000586,
+    SAY_PERIODIC            = -1000582,
+    SAY_QUEST_ACCEPTED      = -1000583,
+    SAY_ATTACKED_1          = -1000584,
     SAY_ATTACKED_2          = -1000585,
-    SAY_QUEST_COMPLETE      = -1000584,
-    EMOTE_WHISPER           = -1000583,
-    EMOTE_DISAPPEAR         = -1000582
+    SAY_QUEST_COMPLETE      = -1000586,
+    EMOTE_WHISPER           = -1000587,
+    EMOTE_DISAPPEAR         = -1000588
 };
 
 struct npc_galen_goodwardAI : public npc_escortAI


### PR DESCRIPTION
Looks like the text entries were numbered the wrong way, causing a rather amusing bug where he tells mobs that attack him where his treasure is, and proclaims he needs help once he's rescued.