### PR TITLE
Fail Skinning attempts if the player isn't within loot range

### DIFF
--- a/src/game/Spells/Spell.cpp
+++ b/src/game/Spells/Spell.cpp
@@ -5593,6 +5593,11 @@ SpellCastResult Spell::CheckCast(bool strict)
                 if (!creature->IsSkinnableBy(m_caster->ToPlayer()))
                     return SPELL_FAILED_TARGET_NOT_LOOTED;
 
+                // If the player isn't in loot range, the skins are lost forever.
+                // This only happens on large mobs with disjointed models (i.e. Devilsaurs).
+                if (!creature->IsWithinDistInMap(m_caster, INTERACTION_DISTANCE))
+                    return SPELL_FAILED_OUT_OF_RANGE;
+
                 uint32 skill = creature->GetCreatureInfo()->GetRequiredLootSkill();
 
                 int32 skillValue = ((Player*)m_caster)->GetSkillValue(skill);


### PR DESCRIPTION
On large corpses with disjointed models (i.e. Devilsaurs with their necks and tail sticking out), the client can think it's in range to skin without also being within the INTERACTION_DISTANCE required to
loot.  If this occurs, the SendLoot() call fails, no loot is retreived, and the corpse is no longer skinnable.

Make sure the player is within looting range of the corpse they're skinning, and if not, report that the spell was out of range.