### PR TITLE
Fix CoA and Starshards bonuses

### DIFF
--- a/sql/migrations/20170625144515_world.sql
+++ b/sql/migrations/20170625144515_world.sql
@@ -1,0 +1,23 @@
+INSERT INTO `migrations` VALUES ('20170625144515');
+ALTER TABLE character_aura
+ADD COLUMN bonus0 INT AFTER basepoints2,
+ADD COLUMN bonus1 INT AFTER bonus0,
+ADD COLUMN bonus2 INT AFTER bonus1,
+ADD COLUMN bonus_pct0 FLOAT AFTER bonus2,
+ADD COLUMN bonus_pct1 FLOAT AFTER bonus_pct0,
+ADD COLUMN bonus_pct2 FLOAT AFTER bonus_pct1,
+ADD COLUMN used0 INT AFTER bonus_pct2,
+ADD COLUMN used1 INT AFTER used0,
+ADD COLUMN used2 INT AFTER used1;
+UPDATE character_aura SET bonus_pct0 = 1, bonus_pct1 = 1, bonus_pct2 = 1;
+ALTER TABLE pet_aura
+ADD COLUMN bonus0 INT AFTER basepoints2,
+ADD COLUMN bonus1 INT AFTER bonus0,
+ADD COLUMN bonus2 INT AFTER bonus1,
+ADD COLUMN bonus_pct0 FLOAT AFTER bonus2,
+ADD COLUMN bonus_pct1 FLOAT AFTER bonus_pct0,
+ADD COLUMN bonus_pct2 FLOAT AFTER bonus_pct1,
+ADD COLUMN used0 INT AFTER bonus_pct2,
+ADD COLUMN used1 INT AFTER used0,
+ADD COLUMN used2 INT AFTER used1;
+UPDATE pet_aura SET bonus_pct0 = 1, bonus_pct1 = 1, bonus_pct2 = 1;

--- a/src/game/Database/CharacterDatabaseCache.cpp
+++ b/src/game/Database/CharacterDatabaseCache.cpp
@@ -187,7 +187,8 @@ void CharacterDatabaseCache::LoadPetAura(uint32 singlePetId)
     {
         result = CharacterDatabase.PQuery(
                      "SELECT guid, caster_guid, item_guid, spell, stackcount, remaincharges, maxduration, remaintime, effIndexMask, "
-                     "basepoints0, basepoints1, basepoints2, periodictime0, periodictime1, periodictime2 "
+                     "basepoints0, basepoints1, basepoints2, bonus0, bonus1, bonus2, bonus_pct0, bonus_pct1, bonus_pct2,"
+                     "used0, used1, used2, periodictime0, periodictime1, periodictime2 "
                      "FROM pet_aura WHERE guid=%u", singlePetId
                  );
     }
@@ -201,8 +202,10 @@ void CharacterDatabaseCache::LoadPetAura(uint32 singlePetId)
         result = CharacterDatabase.Query(
                                   //          0     1             2           3    4           5              6            7              8
                                   "SELECT guid, caster_guid, item_guid, spell, stackcount, remaincharges, maxduration, remaintime, effIndexMask, "
-                                  // 9 -> 11                              12 -> 14
-                                  "basepoints0, basepoints1, basepoints2, periodictime0, periodictime1, periodictime2 "
+                                  // 9 -> 11                                12 -> 14                15 -> 17                            18 -> 20
+                                  "basepoints0, basepoints1, basepoints2, bonus0, bonus1, bonus2, bonus_pct0, bonus_pct1, bonus_pct2, used0, used1, used2,"
+                                  // 21 -> 23
+                                  "periodictime0, periodictime1, periodictime2 "
                                   "FROM pet_aura ORDER BY guid ASC"
                               );
     }
@@ -236,7 +239,10 @@ void CharacterDatabaseCache::LoadPetAura(uint32 singlePetId)
         for (int i = 0; i < 3; ++i)
         {
             _auraStruct.basepoints[i]   = fields[9 + i].GetInt32();
-            _auraStruct.periodictime[i]  = fields[12 + i].GetUInt32();
+            _auraStruct.bonus[i]        = fields[12 + i].GetInt32();
+            _auraStruct.bonus_pct[i]    = fields[15 + i].GetFloat();
+            _auraStruct.used[i]         = fields[18 + i].GetInt32();
+            _auraStruct.periodictime[i] = fields[21 + i].GetUInt32();
         }
 
         if (!_auraStruct.spell)

--- a/src/game/Database/CharacterDatabaseCache.h
+++ b/src/game/Database/CharacterDatabaseCache.h
@@ -30,6 +30,9 @@ struct PetAuraCache
     uint32 effIndexMask;
 
     int32 basepoints[3];
+    int32 bonus[3];
+    float bonus_pct[3];
+    int32 used[3];
     uint32 periodictime[3];
 };
 typedef std::vector<PetAuraCache> PetAuras;

--- a/src/game/Handlers/CharacterHandler.cpp
+++ b/src/game/Handlers/CharacterHandler.cpp
@@ -94,7 +94,7 @@ bool LoginQueryHolder::Initialize()
                      "world_phase_mask, customFlags FROM characters WHERE guid = '%u'", m_guid.GetCounter());
     res &= SetPQuery(PLAYER_LOGIN_QUERY_LOADGROUP,           "SELECT groupId FROM group_member WHERE memberGuid ='%u'", m_guid.GetCounter());
     res &= SetPQuery(PLAYER_LOGIN_QUERY_LOADBOUNDINSTANCES,  "SELECT id, permanent, map, resettime FROM character_instance LEFT JOIN instance ON instance = id WHERE guid = '%u'", m_guid.GetCounter());
-    res &= SetPQuery(PLAYER_LOGIN_QUERY_LOADAURAS,           "SELECT caster_guid,item_guid,spell,stackcount,remaincharges,basepoints0,basepoints1,basepoints2,periodictime0,periodictime1,periodictime2,maxduration,remaintime,effIndexMask FROM character_aura WHERE guid = '%u'", m_guid.GetCounter());
+    res &= SetPQuery(PLAYER_LOGIN_QUERY_LOADAURAS,           "SELECT caster_guid,item_guid,spell,stackcount,remaincharges,basepoints0,basepoints1,basepoints2, bonus0, bonus1, bonus2, bonus_pct0, bonus_pct1, bonus_pct2, used0, used1, used2,periodictime0,periodictime1,periodictime2,maxduration,remaintime,effIndexMask FROM character_aura WHERE guid = '%u'", m_guid.GetCounter());
     res &= SetPQuery(PLAYER_LOGIN_QUERY_LOADSPELLS,          "SELECT spell,active,disabled FROM character_spell WHERE guid = '%u'", m_guid.GetCounter());
     res &= SetPQuery(PLAYER_LOGIN_QUERY_LOADQUESTSTATUS,     "SELECT quest,status,rewarded,explored,timer,mobcount1,mobcount2,mobcount3,mobcount4,itemcount1,itemcount2,itemcount3,itemcount4,reward_choice FROM character_queststatus WHERE guid = '%u'", m_guid.GetCounter());
     res &= SetPQuery(PLAYER_LOGIN_QUERY_LOADHONORCP,         "SELECT victimType,victim,cp,date,type FROM character_honor_cp WHERE guid = '%u'", m_guid.GetCounter());

--- a/src/game/Objects/Creature.cpp
+++ b/src/game/Objects/Creature.cpp
@@ -1673,7 +1673,7 @@ float Creature::GetAttackDistance(Unit const* pl) const
     AuraList const& nModDetectRange = GetAurasByType(SPELL_AURA_MOD_DETECT_RANGE);
     for (AuraList::const_iterator i = nModDetectRange.begin(); i != nModDetectRange.end(); ++i)
         if ((*i)->GetSpellProto()->MaxTargetLevel >= getLevel())
-            RetDistance += (*i)->GetModifier()->m_amount;
+            RetDistance += (*i)->GetModifier()->total();
 
     // detected range auras
     RetDistance += pl->GetTotalAuraModifier(SPELL_AURA_MOD_DETECTED_RANGE);

--- a/src/game/Objects/Pet.cpp
+++ b/src/game/Objects/Pet.cpp
@@ -772,7 +772,7 @@ void Pet::RegenerateFocus()
     AuraList const& ModPowerRegenPCTAuras = GetAurasByType(SPELL_AURA_MOD_POWER_REGEN_PERCENT);
     for (AuraList::const_iterator i = ModPowerRegenPCTAuras.begin(); i != ModPowerRegenPCTAuras.end(); ++i)
         if ((*i)->GetModifier()->m_miscvalue == int32(POWER_FOCUS))
-            addvalue *= ((*i)->GetModifier()->m_amount + 100) / 100.0f;
+            addvalue *= ((*i)->GetModifier()->total() + 100) / 100.0f;
 
     ModifyPower(POWER_FOCUS, (int32)addvalue);
 }
@@ -1656,12 +1656,18 @@ void Pet::_LoadAuras(uint32 timediff)
 
             uint32 stackcount   = it->stackcount;
             int32 remaincharges = (int32)it->remaincharges;
-            int32 damage[MAX_EFFECT_INDEX];
+            int32 base[MAX_EFFECT_INDEX];
+            int32 bonus[MAX_EFFECT_INDEX];
+            int32 bonus_pct[MAX_EFFECT_INDEX];
+            int32 used[MAX_EFFECT_INDEX];
             int32 periodicTime[MAX_EFFECT_INDEX];
 
             for (int32 i = 0; i < MAX_EFFECT_INDEX; ++i)
             {
-                damage[i]      = it->basepoints[i];
+                base[i]         = it->basepoints[i];
+                bonus[i]        = it->bonus[i];
+                bonus_pct[i]    = it->bonus_pct[i];
+                used[i]         = it->used[i];
                 periodicTime[i] = it->periodictime[i];
             }
             int32 maxduration = it->maxduration;
@@ -1707,10 +1713,15 @@ void Pet::_LoadAuras(uint32 timediff)
                     continue;
 
                 Aura* aura = CreateAura(spellproto, SpellEffectIndex(i), nullptr, holder, this);
-                if (!damage[i])
-                    damage[i] = aura->GetModifier()->m_amount;
+                if (!base[i])
+                {
+                    base[i] = aura->GetModifier()->m_base;
+                    bonus[i] = aura->GetModifier()->m_bonus;
+                    bonus_pct[i] = aura->GetModifier()->m_bonus_pct;
+                    used[i] = aura->GetModifier()->m_used;
+                }
 
-                aura->SetLoadedState(damage[i], periodicTime[i]);
+                aura->SetLoadedState(base[i], bonus[i], bonus_pct[i], used[i], periodicTime[i]);
                 holder->AddAura(aura, SpellEffectIndex(i));
             }
 
@@ -1742,8 +1753,8 @@ void Pet::_SaveAuras()
         return;
 
     stmt = CharacterDatabase.CreateStatement(insAuras, "INSERT INTO pet_aura (guid, caster_guid, item_guid, spell, stackcount, remaincharges, "
-            "basepoints0, basepoints1, basepoints2, periodictime0, periodictime1, periodictime2, maxduration, remaintime, effIndexMask) "
-            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)");
+            "basepoints0, basepoints1, basepoints2, bonus0, bonus1, bonus2, bonus_pct0, bonus_pct1, bonus_pct2, used0, used1, used2, periodictime0, periodictime1, periodictime2, maxduration, remaintime, effIndexMask) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)");
 
     for (SpellAuraHolderMap::const_iterator itr = auraHolders.begin(); itr != auraHolders.end(); ++itr)
     {
@@ -1766,13 +1777,19 @@ void Pet::_SaveAuras()
         //do not save single target holders (unless they were cast by the player)
         if (save && !holder->IsPassive() && !IsChanneledSpell(holder->GetSpellProto()) && (holder->GetCasterGuid() == GetObjectGuid() || !holder->IsSingleTarget()))
         {
-            int32  damage[MAX_EFFECT_INDEX];
+            int32  base[MAX_EFFECT_INDEX];
+            int32  bonus[MAX_EFFECT_INDEX];
+            float  bonus_pct[MAX_EFFECT_INDEX];
+            int32  used[MAX_EFFECT_INDEX];
             uint32 periodicTime[MAX_EFFECT_INDEX];
             uint32 effIndexMask = 0;
 
             for (uint32 i = 0; i < MAX_EFFECT_INDEX; ++i)
             {
-                damage[i] = 0;
+                base[i] = 0;
+                bonus[i] = 0;
+                bonus_pct[i] = 1;
+                used[i] = 0;
                 periodicTime[i] = 0;
 
                 if (Aura *aur = holder->GetAuraByEffectIndex(SpellEffectIndex(i)))
@@ -1781,7 +1798,10 @@ void Pet::_SaveAuras()
                     if (aur->IsAreaAura() && holder->GetCasterGuid() != GetObjectGuid())
                         continue;
 
-                    damage[i] = aur->GetModifier()->m_amount;
+                    base[i] = aur->GetModifier()->m_base;
+                    bonus[i] = aur->GetModifier()->m_bonus;
+                    bonus_pct[i] = aur->GetModifier()->m_bonus_pct;
+                    used[i] = aur->GetModifier()->m_used;
                     periodicTime[i] = aur->GetModifier()->periodictime;
                     effIndexMask |= (1 << i);
                 }
@@ -1803,8 +1823,11 @@ void Pet::_SaveAuras()
                 c.remaintime     = holder->GetAuraDuration();
                 for (int i = 0; i < MAX_EFFECT_INDEX; ++i)
                 {
-                    c.basepoints[i]   = damage[i];
-                    c.periodictime[i]  = periodicTime[i];
+                    c.basepoints[i]     = base[i];
+                    c.bonus[i]          = bonus[i];
+                    c.bonus_pct[i]      = bonus_pct[i];
+                    c.used[i]           = used[i];
+                    c.periodictime[i]   = periodicTime[i];
                 }
                 m_pTmpCache->auras.push_back(c);
             }
@@ -1817,7 +1840,13 @@ void Pet::_SaveAuras()
             stmt.addUInt8(holder->GetAuraCharges());
 
             for (uint32 i = 0; i < MAX_EFFECT_INDEX; ++i)
-                stmt.addInt32(damage[i]);
+                stmt.addInt32(base[i]);
+            for (uint32 i = 0; i < MAX_EFFECT_INDEX; ++i)
+                stmt.addInt32(bonus[i]);
+            for (uint32 i = 0; i < MAX_EFFECT_INDEX; ++i)
+                stmt.addFloat(bonus_pct[i]);
+            for (uint32 i = 0; i < MAX_EFFECT_INDEX; ++i)
+                stmt.addInt32(used[i]);
 
             for (uint32 i = 0; i < MAX_EFFECT_INDEX; ++i)
                 stmt.addUInt32(periodicTime[i]);

--- a/src/game/Objects/Player.cpp
+++ b/src/game/Objects/Player.cpp
@@ -957,7 +957,7 @@ int32 Player::getMaxTimer(MirrorTimerType timer)
             int32 UnderWaterTime = sWorld.getConfig(CONFIG_UINT32_TIMERBAR_BREATH_MAX) * IN_MILLISECONDS;
             AuraList const& mModWaterBreathing = GetAurasByType(SPELL_AURA_MOD_WATER_BREATHING);
             for (AuraList::const_iterator i = mModWaterBreathing.begin(); i != mModWaterBreathing.end(); ++i)
-                UnderWaterTime = uint32(UnderWaterTime * (100.0f + (*i)->GetModifier()->m_amount) / 100.0f);
+                UnderWaterTime = uint32(UnderWaterTime * (100.0f + (*i)->GetModifier()->total()) / 100.0f);
             return UnderWaterTime;
         }
         case FIRE_TIMER:
@@ -2263,7 +2263,7 @@ void Player::Regenerate(Powers power)
         AuraList const& ModPowerRegenPCTAuras = GetAurasByType(SPELL_AURA_MOD_POWER_REGEN_PERCENT);
         for (AuraList::const_iterator i = ModPowerRegenPCTAuras.begin(); i != ModPowerRegenPCTAuras.end(); ++i)
             if ((*i)->GetModifier()->m_miscvalue == int32(power))
-                addvalue *= ((*i)->GetModifier()->m_amount + 100) / 100.0f;
+                addvalue *= ((*i)->GetModifier()->total() + 100) / 100.0f;
     }
 
     if (power != POWER_RAGE)
@@ -2304,7 +2304,7 @@ void Player::RegenerateHealth()
         {
             AuraList const& mModHealthRegenPct = GetAurasByType(SPELL_AURA_MOD_HEALTH_REGEN_PERCENT);
             for (AuraList::const_iterator i = mModHealthRegenPct.begin(); i != mModHealthRegenPct.end(); ++i)
-                addvalue *= (100.0f + (*i)->GetModifier()->m_amount) / 100.0f;
+                addvalue *= (100.0f + (*i)->GetModifier()->total()) / 100.0f;
         }
         else if (HasAuraType(SPELL_AURA_MOD_REGEN_DURING_COMBAT))
             addvalue *= GetTotalAuraModifier(SPELL_AURA_MOD_REGEN_DURING_COMBAT) / 100.0f;
@@ -6704,7 +6704,7 @@ void Player::_ApplyWeaponDependentAuraCritMod(Item *item, WeaponAttackType attac
     }
 
     if (item->IsFitToSpellRequirements(aura->GetSpellProto()))
-        HandleBaseModValue(mod, FLAT_MOD, float(aura->GetModifier()->m_amount), apply);
+        HandleBaseModValue(mod, FLAT_MOD, float(aura->GetModifier()->total()), apply);
 }
 
 void Player::_ApplyWeaponDependentAuraDamageMod(Item *item, WeaponAttackType attackType, Aura* aura, bool apply)
@@ -6748,7 +6748,7 @@ void Player::_ApplyWeaponDependentAuraDamageMod(Item *item, WeaponAttackType att
     }
 
     if (item->IsFitToSpellRequirements(aura->GetSpellProto()))
-        HandleStatModifier(unitMod, unitModType, float(modifier->m_amount), apply);
+        HandleStatModifier(unitMod, unitModType, float(modifier->total()), apply);
 }
 
 void Player::ApplyItemEquipSpell(Item *item, bool apply, bool form_change)
@@ -14582,7 +14582,7 @@ void Player::_LoadAuras(QueryResult *result, uint32 timediff)
     for (int i = UNIT_FIELD_AURA; i <= UNIT_FIELD_AURASTATE; ++i)
         SetUInt32Value(i, 0);
 
-    //QueryResult *result = CharacterDatabase.PQuery("SELECT caster_guid,item_guid,spell,stackcount,remaincharges,basepoints0,basepoints1,basepoints2,periodictime0,periodictime1,periodictime2,maxduration,remaintime,effIndexMask FROM character_aura WHERE guid = '%u'",GetGUIDLow());
+    //QueryResult *result = CharacterDatabase.PQuery("SELECT caster_guid,item_guid,spell,stackcount,remaincharges,basepoints0,basepoints1,basepoints2, bonus0, bonus1, bonus2, bonus_pct0, bonus_pct1, bonus_pct2, used0, used1, used2,periodictime0,periodictime1,periodictime2,maxduration,remaintime,effIndexMask FROM character_aura WHERE guid = '%u'",GetGUIDLow());
 
     if (result)
     {
@@ -14598,13 +14598,16 @@ void Player::_LoadAuras(QueryResult *result, uint32 timediff)
 
             for (int32 i = 0; i < MAX_EFFECT_INDEX; ++i)
             {
-                s.damage[i] = fields[i + 5].GetInt32();
-                s.periodicTime[i] = fields[i + 8].GetUInt32();
+                s.base[i] = fields[i + 5].GetInt32();
+                s.bonus[i] = fields[i + 8].GetInt32();
+                s.bonus_pct[i] = fields[i + 11].GetFloat();
+                s.used[i] = fields[i + 14].GetInt32();
+                s.periodicTime[i] = fields[i + 17].GetUInt32();
             }
 
-            s.maxduration = fields[11].GetInt32();
-            s.remaintime = fields[12].GetInt32();
-            s.effIndexMask = fields[13].GetUInt32();
+            s.maxduration = fields[20].GetInt32();
+            s.remaintime = fields[21].GetInt32();
+            s.effIndexMask = fields[22].GetUInt32();
 
             LoadAura(s, timediff);
         }
@@ -14655,10 +14658,15 @@ void Player::LoadAura(AuraSaveStruct& s, uint32 timediff)
             continue;
 
         Aura* aura = CreateAura(spellproto, SpellEffectIndex(i), NULL, holder, this);
-        if (!s.damage[i])
-            s.damage[i] = aura->GetModifier()->m_amount;
+        if (!s.base[i])
+        {
+            s.base[i] = aura->GetModifier()->m_base;
+            s.bonus[i] = aura->GetModifier()->m_bonus;
+            s.bonus_pct[i] = aura->GetModifier()->m_bonus_pct;
+            s.used[i] = aura->GetModifier()->m_used;
+        }
 
-        aura->SetLoadedState(s.damage[i], s.periodicTime[i]);
+        aura->SetLoadedState(s.base[i], s.bonus[i], s.bonus_pct[i], s.used[i], s.periodicTime[i]);
         holder->AddAura(aura, SpellEffectIndex(i));
     }
 
@@ -15591,6 +15599,48 @@ void Player::SaveGoldToDB()
     stmt.PExecute(GetMoney(), GetGUIDLow());
 }
 
+void Player::ApplySpellMod(uint32 spellId, SpellModOp op, Modifier *basevalue, Spell* spell)
+{
+    SpellEntry const *spellInfo = sSpellMgr.GetSpellEntry(spellId);
+    if (!spellInfo) return;
+    int32 totalpct = 0;
+    int32 totalflat = 0;
+    for (SpellModList::iterator itr = m_spellMods[op].begin(); itr != m_spellMods[op].end(); ++itr)
+    {
+        SpellModifier *mod = *itr;
+
+        if (!IsAffectedBySpellmod(spellInfo,mod,spell))
+            continue;
+
+        if (mod->type == SPELLMOD_FLAT)
+            totalflat += mod->value;
+        else if (mod->type == SPELLMOD_PCT)
+        {
+            // skip percent mods for null basevalue (most important for spell mods with charges )
+            if(basevalue->total() == 0)
+                continue;
+
+            // special case (skip >10sec spell casts for instant cast setting)
+            if( mod->op==SPELLMOD_CASTING_TIME  && basevalue->total() >= 10*IN_MILLISECONDS && mod->value <= -100)
+                continue;
+
+            totalpct += mod->value;
+        }
+
+        DropModCharge(mod, spell);
+
+        // Nostalrius : fix ecorce (22812 - +1sec incant) + rapidite nature (17116 - sorts instant) = 0sec de cast
+        if (mod->op == SPELLMOD_CASTING_TIME && mod->type == SPELLMOD_PCT && mod->value == -100)
+        {
+            totalpct = -100;
+            totalflat = 0;
+            break;
+        }
+    }
+
+    basevalue->m_bonus += (float)basevalue->total()*(float)totalpct/100.0f + (float)totalflat;
+}
+
 void Player::_SaveAuras()
 {
     static SqlStatementID deleteAuras ;
@@ -15605,8 +15655,8 @@ void Player::_SaveAuras()
         return;
 
     stmt = CharacterDatabase.CreateStatement(insertAuras, "INSERT INTO character_aura (guid, caster_guid, item_guid, spell, stackcount, remaincharges, "
-            "basepoints0, basepoints1, basepoints2, periodictime0, periodictime1, periodictime2, maxduration, remaintime, effIndexMask) "
-            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)");
+            "basepoints0, basepoints1, basepoints2, bonus0, bonus1, bonus2, bonus_pct0, bonus_pct1, bonus_pct2, used0, used1, used2, periodictime0, periodictime1, periodictime2, maxduration, remaintime, effIndexMask) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)");
 
     AuraSaveStruct s;
     for (SpellAuraHolderMap::const_iterator itr = auraHolders.begin(); itr != auraHolders.end(); ++itr)
@@ -15624,7 +15674,13 @@ void Player::_SaveAuras()
         stmt.addUInt8(s.remaincharges);
 
         for (uint32 i = 0; i < MAX_EFFECT_INDEX; ++i)
-            stmt.addInt32(s.damage[i]);
+            stmt.addInt32(s.base[i]);
+        for (uint32 i = 0; i < MAX_EFFECT_INDEX; ++i)
+            stmt.addInt32(s.bonus[i]);
+        for (uint32 i = 0; i < MAX_EFFECT_INDEX; ++i)
+            stmt.addFloat(s.bonus_pct[i]);
+        for (uint32 i = 0; i < MAX_EFFECT_INDEX; ++i)
+            stmt.addInt32(s.used[i]);
 
         for (uint32 i = 0; i < MAX_EFFECT_INDEX; ++i)
             stmt.addUInt32(s.periodicTime[i]);
@@ -15650,7 +15706,10 @@ bool Player::SaveAura(SpellAuraHolder* holder, AuraSaveStruct& saveStruct)
 
         for (uint32 i = 0; i < MAX_EFFECT_INDEX; ++i)
         {
-            saveStruct.damage[i] = 0;
+            saveStruct.base[i] = 0;
+            saveStruct.bonus[i] = 0;
+            saveStruct.bonus_pct[i] = 1;
+            saveStruct.used[i] = 0;
             saveStruct.periodicTime[i] = 0;
 
             if (Aura *aur = holder->GetAuraByEffectIndex(SpellEffectIndex(i)))
@@ -15659,7 +15718,10 @@ bool Player::SaveAura(SpellAuraHolder* holder, AuraSaveStruct& saveStruct)
                 if (aur->IsAreaAura() && holder->GetCasterGuid() != GetObjectGuid())
                     return false;
 
-                saveStruct.damage[i] = aur->GetModifier()->m_amount;
+                saveStruct.base[i] = aur->GetModifier()->m_base;
+                saveStruct.bonus[i] = aur->GetModifier()->m_bonus;
+                saveStruct.bonus_pct[i] = aur->GetModifier()->m_bonus_pct;
+                saveStruct.used[i] = aur->GetModifier()->m_used;
                 saveStruct.periodicTime[i] = aur->GetModifier()->periodictime;
                 saveStruct.effIndexMask |= (1 << i);
             }

--- a/src/game/Objects/Player.h
+++ b/src/game/Objects/Player.h
@@ -824,7 +824,10 @@ struct AuraSaveStruct
     uint32 spellid;
     uint32 stackcount;
     uint32 remaincharges;
-    int32  damage[MAX_EFFECT_INDEX];
+    int32  base[MAX_EFFECT_INDEX];
+    int32  bonus[MAX_EFFECT_INDEX];
+    int32  bonus_pct[MAX_EFFECT_INDEX];
+    int32  used[MAX_EFFECT_INDEX];
     uint32 periodicTime[MAX_EFFECT_INDEX];
 
     int32 maxduration;
@@ -1429,6 +1432,7 @@ class MANGOS_DLL_SPEC Player final: public Unit
         void AddSpellMod(SpellModifier* mod, bool apply);
         void SendSpellMod(SpellModifier const* mod);
         bool IsAffectedBySpellmod(SpellEntry const *spellInfo, SpellModifier *mod, Spell* spell = NULL);
+        void ApplySpellMod(uint32 spellId, SpellModOp op, Modifier *basevalue, Spell* spell = nullptr);
         template <class T> T ApplySpellMod(uint32 spellId, SpellModOp op, T &basevalue, Spell* spell = NULL);
         SpellModifier* GetSpellMod(SpellModOp op, uint32 spellId) const;
         void RemoveSpellMods(Spell* spell);

--- a/src/game/Objects/Unit.cpp
+++ b/src/game/Objects/Unit.cpp
@@ -1932,7 +1932,7 @@ void Unit::DealMeleeDamage(CalcDamageInfo *damageInfo, bool durabilityLoss)
             if (alreadyDone.find(*i) == alreadyDone.end())
             {
                 alreadyDone.insert(*i);
-                uint32 damage = (*i)->GetModifier()->m_amount;
+                uint32 damage = (*i)->GetModifier()->total();
                 SpellEntry const *i_spellProto = (*i)->GetSpellProto();
 
                 // apply SpellBaseDamageBonusTaken for mobs only
@@ -2179,7 +2179,7 @@ void Unit::CalculateDamageAbsorbAndResist(Unit *pCaster, SpellSchoolMask schoolM
             continue;
 
         // Max Amount can be absorbed by this aura
-        int32  currentAbsorb = mod->m_amount;
+        int32  currentAbsorb = mod->remaning();
 
         // Found empty aura (impossible but..)
         if (currentAbsorb <= 0)
@@ -2196,11 +2196,13 @@ void Unit::CalculateDamageAbsorbAndResist(Unit *pCaster, SpellSchoolMask schoolM
         RemainingDamage -= currentAbsorb;
 
         // Reduce shield amount
-        mod->m_amount -= currentAbsorb;
+        mod->m_used += currentAbsorb;
         if ((*i)->GetHolder()->DropAuraCharge())
-            mod->m_amount = 0;
+        {
+            mod->m_used = mod->total();
+        }
         // Need remove it later
-        if (mod->m_amount <= 0)
+        if (mod->remaning() <= 0)
             existExpired = true;
     }
 
@@ -2209,7 +2211,7 @@ void Unit::CalculateDamageAbsorbAndResist(Unit *pCaster, SpellSchoolMask schoolM
     {
         for (AuraList::const_iterator i = vSchoolAbsorb.begin(); i != vSchoolAbsorb.end();)
         {
-            if ((*i)->GetModifier()->m_amount <= 0)
+            if ((*i)->GetModifier()->remaning() <= 0)
             {
                 RemoveAurasDueToSpell((*i)->GetId(), nullptr, AURA_REMOVE_BY_SHIELD_BREAK);
                 i = vSchoolAbsorb.begin();
@@ -2231,8 +2233,8 @@ void Unit::CalculateDamageAbsorbAndResist(Unit *pCaster, SpellSchoolMask schoolM
             continue;
 
         int32 currentAbsorb;
-        if (RemainingDamage >= (*i)->GetModifier()->m_amount)
-            currentAbsorb = (*i)->GetModifier()->m_amount;
+        if (RemainingDamage >= (*i)->GetModifier()->remaning())
+            currentAbsorb = (*i)->GetModifier()->remaning();
         else
             currentAbsorb = RemainingDamage;
 
@@ -2249,8 +2251,8 @@ void Unit::CalculateDamageAbsorbAndResist(Unit *pCaster, SpellSchoolMask schoolM
             ApplyPowerMod(POWER_MANA, manaReduction, false);
         }
 
-        (*i)->GetModifier()->m_amount -= currentAbsorb;
-        if ((*i)->GetModifier()->m_amount <= 0)
+        (*i)->GetModifier()->m_used += currentAbsorb;
+        if ((*i)->GetModifier()->remaning() <= 0)
         {
             RemoveAurasDueToSpell((*i)->GetId());
             next = vManaShield.begin();
@@ -2278,8 +2280,8 @@ void Unit::CalculateDamageAbsorbAndResist(Unit *pCaster, SpellSchoolMask schoolM
                 continue;
 
             int32 currentAbsorb;
-            if (RemainingDamage >= (*i)->GetModifier()->m_amount)
-                currentAbsorb = (*i)->GetModifier()->m_amount;
+            if (RemainingDamage >= (*i)->GetModifier()->remaning())
+                currentAbsorb = (*i)->GetModifier()->remaning();
             else
                 currentAbsorb = RemainingDamage;
 
@@ -2314,7 +2316,7 @@ void Unit::CalculateDamageAbsorbAndResist(Unit *pCaster, SpellSchoolMask schoolM
             if (!caster || caster == this || !caster->IsInWorld() || !caster->isAlive())
                 continue;
 
-            uint32 splitted = uint32(RemainingDamage * (*i)->GetModifier()->m_amount / 100.0f);
+            uint32 splitted = uint32(RemainingDamage * (*i)->GetModifier()->remaning() / 100.0f);
 
             RemainingDamage -=  int32(splitted);
 
@@ -3030,7 +3032,7 @@ SpellMissInfo Unit::SpellHitResult(Unit *pVictim, SpellEntry const *spell, Spell
         Unit::AuraList const& mReflectSpellsSchool = pVictim->GetAurasByType(SPELL_AURA_REFLECT_SPELLS_SCHOOL);
         for (Unit::AuraList::const_iterator i = mReflectSpellsSchool.begin(); i != mReflectSpellsSchool.end(); ++i)
             if ((*i)->GetModifier()->m_miscvalue & GetSpellSchoolMask(spell))
-                reflectchance += (*i)->GetModifier()->m_amount;
+                reflectchance += (*i)->GetModifier()->total();
         if (reflectchance > 0 && roll_chance_i(reflectchance))
         {
             // Start triggers for remove charges if need (trigger only for victim, and mark as active spell)
@@ -3638,7 +3640,7 @@ int32 Unit::GetTotalAuraModifier(AuraType auratype) const
         // Exception for stealth detection, remove hidden trap detection (id:2836) from stealth modifier (should not be taken into account)
         // If it was the cast, rogue will see others rogue at 40 meters
         if ((*i)->GetId() != 2836)
-            modifier += (*i)->GetModifier()->m_amount;
+            modifier += (*i)->GetModifier()->total();
     }
 
 
@@ -3651,7 +3653,7 @@ float Unit::GetTotalAuraMultiplier(AuraType auratype) const
 
     AuraList const& mTotalAuraList = GetAurasByType(auratype);
     for (AuraList::const_iterator i = mTotalAuraList.begin(); i != mTotalAuraList.end(); ++i)
-        multiplier *= (100.0f + (*i)->GetModifier()->m_amount) / 100.0f;
+        multiplier *= (100.0f + (*i)->GetModifier()->total()) / 100.0f;
 
     return multiplier;
 }
@@ -3662,8 +3664,8 @@ int32 Unit::GetMaxPositiveAuraModifier(AuraType auratype) const
 
     AuraList const& mTotalAuraList = GetAurasByType(auratype);
     for (AuraList::const_iterator i = mTotalAuraList.begin(); i != mTotalAuraList.end(); ++i)
-        if ((*i)->GetModifier()->m_amount > modifier)
-            modifier = (*i)->GetModifier()->m_amount;
+        if ((*i)->GetModifier()->total() > modifier)
+            modifier = (*i)->GetModifier()->total();
 
     return modifier;
 }
@@ -3674,8 +3676,8 @@ int32 Unit::GetMaxNegativeAuraModifier(AuraType auratype) const
 
     AuraList const& mTotalAuraList = GetAurasByType(auratype);
     for (AuraList::const_iterator i = mTotalAuraList.begin(); i != mTotalAuraList.end(); ++i)
-        if ((*i)->GetModifier()->m_amount < modifier)
-            modifier = (*i)->GetModifier()->m_amount;
+        if ((*i)->GetModifier()->total() < modifier)
+            modifier = (*i)->GetModifier()->total();
 
     return modifier;
 }
@@ -3692,7 +3694,7 @@ int32 Unit::GetTotalAuraModifierByMiscMask(AuraType auratype, uint32 misc_mask) 
     {
         Modifier* mod = (*i)->GetModifier();
         if (mod->m_miscvalue & misc_mask)
-            modifier += mod->m_amount;
+            modifier += mod->total();
     }
     return modifier;
 }
@@ -3709,7 +3711,7 @@ float Unit::GetTotalAuraMultiplierByMiscMask(AuraType auratype, uint32 misc_mask
     {
         Modifier* mod = (*i)->GetModifier();
         if (mod->m_miscvalue & misc_mask)
-            multiplier *= (100.0f + mod->m_amount) / 100.0f;
+            multiplier *= (100.0f + mod->total()) / 100.0f;
     }
     return multiplier;
 }
@@ -3725,8 +3727,8 @@ int32 Unit::GetMaxPositiveAuraModifierByMiscMask(AuraType auratype, uint32 misc_
     for (AuraList::const_iterator i = mTotalAuraList.begin(); i != mTotalAuraList.end(); ++i)
     {
         Modifier* mod = (*i)->GetModifier();
-        if (mod->m_miscvalue & misc_mask && mod->m_amount > modifier)
-            modifier = mod->m_amount;
+        if (mod->m_miscvalue & misc_mask && mod->total() > modifier)
+            modifier = mod->total();
     }
 
     return modifier;
@@ -3743,8 +3745,8 @@ int32 Unit::GetMaxNegativeAuraModifierByMiscMask(AuraType auratype, uint32 misc_
     for (AuraList::const_iterator i = mTotalAuraList.begin(); i != mTotalAuraList.end(); ++i)
     {
         Modifier* mod = (*i)->GetModifier();
-        if (mod->m_miscvalue & misc_mask && mod->m_amount < modifier)
-            modifier = mod->m_amount;
+        if (mod->m_miscvalue & misc_mask && mod->total() < modifier)
+            modifier = mod->total();
     }
 
     return modifier;
@@ -3759,7 +3761,7 @@ int32 Unit::GetTotalAuraModifierByMiscValue(AuraType auratype, int32 misc_value)
     {
         Modifier* mod = (*i)->GetModifier();
         if (mod->m_miscvalue == misc_value)
-            modifier += mod->m_amount;
+            modifier += mod->total();
     }
     return modifier;
 }
@@ -3773,7 +3775,7 @@ float Unit::GetTotalAuraMultiplierByMiscValue(AuraType auratype, int32 misc_valu
     {
         Modifier* mod = (*i)->GetModifier();
         if (mod->m_miscvalue == misc_value)
-            multiplier *= (100.0f + mod->m_amount) / 100.0f;
+            multiplier *= (100.0f + mod->total()) / 100.0f;
     }
     return multiplier;
 }
@@ -3786,8 +3788,8 @@ int32 Unit::GetMaxPositiveAuraModifierByMiscValue(AuraType auratype, int32 misc_
     for (AuraList::const_iterator i = mTotalAuraList.begin(); i != mTotalAuraList.end(); ++i)
     {
         Modifier* mod = (*i)->GetModifier();
-        if (mod->m_miscvalue == misc_value && mod->m_amount > modifier)
-            modifier = mod->m_amount;
+        if (mod->m_miscvalue == misc_value && mod->total() > modifier)
+            modifier = mod->total();
     }
 
     return modifier;
@@ -3801,8 +3803,8 @@ int32 Unit::GetMaxNegativeAuraModifierByMiscValue(AuraType auratype, int32 misc_
     for (AuraList::const_iterator i = mTotalAuraList.begin(); i != mTotalAuraList.end(); ++i)
     {
         Modifier* mod = (*i)->GetModifier();
-        if (mod->m_miscvalue == misc_value && mod->m_amount < modifier)
-            modifier = mod->m_amount;
+        if (mod->m_miscvalue == misc_value && mod->total() < modifier)
+            modifier = mod->total();
     }
 
     return modifier;
@@ -6186,20 +6188,23 @@ int32 Unit::SpellBonusWithCoeffs(SpellEntry const *spellProto, int32 total, int3
  * Calculates caster part of spell damage bonuses,
  * also includes different bonuses dependent from target auras
  */
-uint32 Unit::SpellDamageBonusDone(Unit *pVictim, SpellEntry const *spellProto, uint32 pdamage, DamageEffectType damagetype, uint32 stack, Spell* spell)
+void Unit::SpellDamageBonusDone(Unit *pVictim, SpellEntry const *spellProto, Modifier *pdamage, DamageEffectType damagetype, uint32 stack, Spell* spell)
 {
     if (!spellProto || !pVictim || damagetype == DIRECT_DAMAGE)
-        return pdamage;
+        return;
 
     // Ignite damage already includes modifiers
     if (spellProto->IsFitToFamily<SPELLFAMILY_MAGE, CF_MAGE_IGNITE>())
-        return pdamage;
+        return;
 
     // For totems get damage bonus from owner (statue isn't totem in fact)
     if (GetTypeId() == TYPEID_UNIT && ((Creature*)this)->IsTotem() && ((Totem*)this)->GetTotemType() != TOTEM_STATUE)
     {
         if (Unit* owner = GetOwner())
-            return owner->SpellDamageBonusDone(pVictim, spellProto, pdamage, damagetype, stack, spell);
+        {
+            owner->SpellDamageBonusDone(pVictim, spellProto, pdamage, damagetype, stack, spell);
+            return;
+        }
     }
 
     float DoneTotalMod = 1.0f;
@@ -6218,14 +6223,14 @@ uint32 Unit::SpellDamageBonusDone(Unit *pVictim, SpellEntry const *spellProto, u
                 // -1 == any item class (not wand then)
                 (*i)->GetSpellProto()->EquippedItemInventoryTypeMask == 0)
             // 0 == any inventory type (not wand then)
-            DoneTotalMod *= ((*i)->GetModifier()->m_amount + 100.0f) / 100.0f;
+            DoneTotalMod *= ((*i)->GetModifier()->total() + 100.0f) / 100.0f;
 
         // Paladin seals benefit from weapon modifiers
         else if ((*i)->GetModifier()->m_miscvalue & GetMeleeDamageSchoolMask() &&
             spellProto->SpellFamilyName == SPELLFAMILY_PALADIN && spellProto->IsFitToFamilyMask<CF_PALADIN_SEALS>() &&
             (((*i)->GetSpellProto()->EquippedItemClass == -1) ||
             (pWeapon && pWeapon->IsFitToSpellRequirements((*i)->GetSpellProto()))))
-            DoneTotalMod *= ((*i)->GetModifier()->m_amount + 100.0f) / 100.0f;
+            DoneTotalMod *= ((*i)->GetModifier()->total() + 100.0f) / 100.0f;
     }
 
     uint32 creatureTypeMask = pVictim->GetCreatureTypeMask();
@@ -6250,7 +6255,7 @@ uint32 Unit::SpellDamageBonusDone(Unit *pVictim, SpellEntry const *spellProto, u
             case 4554: // Increased Lightning Damage
             case 4555: // Improved Moonfire
             {
-                DoneTotal += (*i)->GetModifier()->m_amount;
+                DoneTotal += (*i)->GetModifier()->total();
                 break;
             }
         }
@@ -6284,13 +6289,14 @@ uint32 Unit::SpellDamageBonusDone(Unit *pVictim, SpellEntry const *spellProto, u
     // apply ap bonus and benefit affected by spell power implicit coeffs and spell level penalties
     DoneTotal = SpellBonusWithCoeffs(spellProto, DoneTotal, DoneAdvertisedBenefit, 0, damagetype, true, this, spell);
 
-    float tmpDamage = (int32(pdamage) + DoneTotal * int32(stack)) * DoneTotalMod;
+    pdamage->m_bonus += DoneTotal * stack;
+    pdamage->m_bonus_pct *= DoneTotalMod;
     // apply spellmod to Done damage (flat and pct)
     if (Player* modOwner = GetSpellModOwner())
-        modOwner->ApplySpellMod(spellProto->Id, damagetype == DOT ? SPELLMOD_DOT : SPELLMOD_DAMAGE, tmpDamage, spell);
+        modOwner->ApplySpellMod(spellProto->Id, damagetype == DOT ? SPELLMOD_DOT : SPELLMOD_DAMAGE, pdamage, spell);
 
-    DEBUG_UNIT(this, DEBUG_SPELLS_DAMAGE, "SpellDmgBonus[spell=%u]: (base=%u + %i) * %f. SP=%i", spellProto->Id, pdamage, DoneTotal, DoneTotalMod, DoneAdvertisedBenefit);
-    return tmpDamage > 0 ? uint32(tmpDamage) : 0;
+    DEBUG_UNIT(this, DEBUG_SPELLS_DAMAGE, "SpellDmgBonus[spell=%u]: (base=%u + %i) * %f. SP=%i", spellProto->Id, pdamage->total(), DoneTotal, DoneTotalMod, DoneAdvertisedBenefit);
+    return;
 }
 
 /**
@@ -6333,7 +6339,7 @@ int32 Unit::SpellBaseDamageBonusDone(SpellSchoolMask schoolMask)
         if (((*i)->GetModifier()->m_miscvalue & schoolMask) != 0 &&
                 (*i)->GetSpellProto()->EquippedItemClass == -1 &&                   // -1 == any item class (not wand then)
                 (*i)->GetSpellProto()->EquippedItemInventoryTypeMask == 0)          //  0 == any inventory type (not wand then)
-            DoneAdvertisedBenefit += (*i)->GetModifier()->m_amount;
+            DoneAdvertisedBenefit += (*i)->GetModifier()->total();
     }
 
     if (GetTypeId() == TYPEID_PLAYER)
@@ -6346,7 +6352,7 @@ int32 Unit::SpellBaseDamageBonusDone(SpellSchoolMask schoolMask)
             {
                 // stat used stored in miscValueB for this aura
                 Stats usedStat = STAT_SPIRIT;
-                DoneAdvertisedBenefit += int32(GetStat(usedStat) * (*i)->GetModifier()->m_amount / 100.0f);
+                DoneAdvertisedBenefit += int32(GetStat(usedStat) * (*i)->GetModifier()->total() / 100.0f);
             }
         }
     }
@@ -6362,10 +6368,21 @@ int32 Unit::SpellBaseDamageBonusTaken(SpellSchoolMask schoolMask)
     for (AuraList::const_iterator i = mDamageTaken.begin(); i != mDamageTaken.end(); ++i)
     {
         if (((*i)->GetModifier()->m_miscvalue & schoolMask) != 0)
-            TakenAdvertisedBenefit += (*i)->GetModifier()->m_amount;
+            TakenAdvertisedBenefit += (*i)->GetModifier()->total();
     }
 
     return TakenAdvertisedBenefit;
+}
+
+uint32 Unit::SpellDamageBonusDone(Unit *pVictim, const SpellEntry *spellProto, uint32 pdamage, DamageEffectType damagetype, uint32 stack, Spell *spell)
+{
+    Modifier m;
+    m.m_base = pdamage;
+    m.m_bonus = 0;
+    m.m_bonus_pct = 1;
+    SpellDamageBonusDone(pVictim, spellProto, &m, damagetype, stack, spell);
+    int ret = m.total();
+    return ret > 0 ? ret : 0;
 }
 
 bool Unit::IsSpellCrit(Unit *pVictim, SpellEntry const *spellProto, SpellSchoolMask schoolMask, WeaponAttackType attackType, Spell* spell)
@@ -6536,18 +6553,21 @@ uint32 Unit::SpellCriticalHealingBonus(SpellEntry const *spellProto, uint32 dama
  * Calculates caster part of healing spell bonuses,
  * also includes different bonuses dependent from target auras
  */
-uint32 Unit::SpellHealingBonusDone(Unit *pVictim, SpellEntry const *spellProto, int32 healamount, DamageEffectType damagetype, uint32 stack, Spell* spell)
+void Unit::SpellHealingBonusDone(Unit *pVictim, SpellEntry const *spellProto, Modifier *healamount, DamageEffectType damagetype, uint32 stack, Spell* spell)
 {
     // For totems get healing bonus from owner (statue isn't totem in fact)
     if (GetTypeId() == TYPEID_UNIT && ((Creature*)this)->IsTotem() && ((Totem*)this)->GetTotemType() != TOTEM_STATUE)
         if (Unit* owner = GetOwner())
-            return owner->SpellHealingBonusDone(pVictim, spellProto, healamount, damagetype, stack, spell);
+        {
+            owner->SpellHealingBonusDone(pVictim, spellProto, healamount, damagetype, stack, spell);
+            return;
+        }
 
     // No heal amount for this class spells
     if (spellProto->DmgClass == SPELL_DAMAGE_CLASS_NONE || spellProto->Custom & SPELL_CUSTOM_FIXED_DAMAGE)
     {
         DEBUG_UNIT(this, DEBUG_SPELLS_DAMAGE, "SpellHealingBonusDone[spell=%u]: has fixed damage (SPELL_DAMAGE_CLASS_NONE)", spellProto->Id);
-        return healamount < 0 ? 0 : healamount;
+        return;
     }
     // Healing Done
     // Done total percent damage auras
@@ -6557,7 +6577,7 @@ uint32 Unit::SpellHealingBonusDone(Unit *pVictim, SpellEntry const *spellProto, 
     // Healing done percent
     AuraList const& mHealingDonePct = GetAurasByType(SPELL_AURA_MOD_HEALING_DONE_PERCENT);
     for (AuraList::const_iterator i = mHealingDonePct.begin(); i != mHealingDonePct.end(); ++i)
-        DoneTotalMod *= (100.0f + (*i)->GetModifier()->m_amount) / 100.0f;
+        DoneTotalMod *= (100.0f + (*i)->GetModifier()->total()) / 100.0f;
 
     // done scripted mod (take it from owner)
     Unit *owner = GetOwner();
@@ -6571,10 +6591,10 @@ uint32 Unit::SpellHealingBonusDone(Unit *pVictim, SpellEntry const *spellProto, 
         switch ((*i)->GetModifier()->m_miscvalue)
         {
             case 4415: // Increased Rejuvenation Healing
-                DoneTotal += (*i)->GetModifier()->m_amount / 4; // 4 ticks
+                DoneTotal += (*i)->GetModifier()->total() / 4; // 4 ticks
                 break;
             case 3736: // Hateful Totem of the Third Wind / Increased Lesser Healing Wave / Savage Totem of the Third Wind
-                DoneTotal += (*i)->GetModifier()->m_amount;
+                DoneTotal += (*i)->GetModifier()->total();
                 break;
             default:
                 break;
@@ -6588,13 +6608,25 @@ uint32 Unit::SpellHealingBonusDone(Unit *pVictim, SpellEntry const *spellProto, 
     DoneTotal = SpellBonusWithCoeffs(spellProto, DoneTotal, DoneAdvertisedBenefit, 0, damagetype, true, this, spell);
 
     // use float as more appropriate for negative values and percent applying
-    float heal = (healamount + DoneTotal * int32(stack)) * DoneTotalMod;
+    healamount->m_bonus += DoneTotal * stack;
+    healamount->m_bonus_pct *= DoneTotalMod;
     // apply spellmod to Done amount
     if (Player* modOwner = GetSpellModOwner())
-        modOwner->ApplySpellMod(spellProto->Id, damagetype == DOT ? SPELLMOD_DOT : SPELLMOD_DAMAGE, heal, spell);
+        modOwner->ApplySpellMod(spellProto->Id, damagetype == DOT ? SPELLMOD_DOT : SPELLMOD_DAMAGE, healamount, spell);
 
     DEBUG_UNIT(this, DEBUG_SPELLS_DAMAGE, "SpellHealingBonusDone[spell=%u]: (base=%u + %i) * %f. HealingPwr=%i", spellProto->Id, healamount, DoneTotal, DoneTotalMod, DoneAdvertisedBenefit);
-    return heal < 0 ? 0 : uint32(heal);
+    return;
+}
+
+uint32 Unit::SpellHealingBonusDone(Unit *pVictim, const SpellEntry *spellProto, int32 healamount, DamageEffectType damagetype, uint32 stack, Spell *spell)
+{
+    Modifier m;
+    m.m_base = healamount;
+    m.m_bonus = 0;
+    m.m_bonus_pct = 1;
+    SpellHealingBonusDone(pVictim, spellProto, &m, damagetype, stack, spell);
+    int ret = m.total();
+    return ret > 0 ? ret : 0;
 }
 
 /**
@@ -6636,15 +6668,15 @@ uint32 Unit::SpellHealingBonusTaken(Unit *pCaster, SpellEntry const *spellProto,
         {
             // Libram of Divinity
             if ((*i)->GetSpellProto()->Id == 28851 && spellProto->IsFitToFamilyMask<CF_PALADIN_FLASH_OF_LIGHT1>())
-                TakenTotal += (*i)->GetModifier()->m_amount;
+                TakenTotal += (*i)->GetModifier()->total();
             if ((*i)->GetSpellProto()->IsFitToFamilyMask<CF_PALADIN_BLESSINGS>() && (*i)->GetSpellProto()->SpellVisual == 300)
             {
                 // Holy Light
                 if (spellProto->IsFitToFamilyMask<CF_PALADIN_HOLY_LIGHT2>() && (*i)->GetEffIndex() == EFFECT_INDEX_0)
-                    TakenTotal += (*i)->GetModifier()->m_amount;
+                    TakenTotal += (*i)->GetModifier()->total();
                 // Flash of Light
                 else if (spellProto->IsFitToFamilyMask<CF_PALADIN_FLASH_OF_LIGHT1>() && (*i)->GetEffIndex() == EFFECT_INDEX_1)
-                    TakenTotal += (*i)->GetModifier()->m_amount;
+                    TakenTotal += (*i)->GetModifier()->total();
             }
         }
     }
@@ -6659,7 +6691,7 @@ uint32 Unit::SpellHealingBonusTaken(Unit *pCaster, SpellEntry const *spellProto,
         Unit::AuraList const& auraDummy = GetAurasByType(SPELL_AURA_DUMMY);
         for (Unit::AuraList::const_iterator itr = auraDummy.begin(); itr != auraDummy.end(); ++itr)
             if ((*itr)->GetId() == 29203)
-                TakenTotalMod *= ((*itr)->GetModifier()->m_amount + 100.0f) / 100.0f;
+                TakenTotalMod *= ((*itr)->GetModifier()->total() + 100.0f) / 100.0f;
     }
 
 
@@ -6676,7 +6708,7 @@ int32 Unit::SpellBaseHealingBonusDone(SpellSchoolMask schoolMask)
     AuraList const& mHealingDone = GetAurasByType(SPELL_AURA_MOD_HEALING_DONE);
     for (AuraList::const_iterator i = mHealingDone.begin(); i != mHealingDone.end(); ++i)
         if (((*i)->GetModifier()->m_miscvalue & schoolMask) != 0)
-            AdvertisedBenefit += (*i)->GetModifier()->m_amount;
+            AdvertisedBenefit += (*i)->GetModifier()->total();
 
     // Healing bonus of spirit, intellect and strength
     if (GetTypeId() == TYPEID_PLAYER)
@@ -6687,7 +6719,7 @@ int32 Unit::SpellBaseHealingBonusDone(SpellSchoolMask schoolMask)
         {
             // 1.12.* have only 1 stat type support
             Stats usedStat = STAT_SPIRIT;
-            AdvertisedBenefit += int32(GetStat(usedStat) * (*i)->GetModifier()->m_amount / 100.0f);
+            AdvertisedBenefit += int32(GetStat(usedStat) * (*i)->GetModifier()->total() / 100.0f);
         }
     }
     return AdvertisedBenefit;
@@ -6699,7 +6731,7 @@ int32 Unit::SpellBaseHealingBonusTaken(SpellSchoolMask schoolMask)
     AuraList const& mDamageTaken = GetAurasByType(SPELL_AURA_MOD_HEALING);
     for (AuraList::const_iterator i = mDamageTaken.begin(); i != mDamageTaken.end(); ++i)
         if ((*i)->GetModifier()->m_miscvalue & schoolMask)
-            AdvertisedBenefit += (*i)->GetModifier()->m_amount;
+            AdvertisedBenefit += (*i)->GetModifier()->total();
 
     return AdvertisedBenefit;
 }
@@ -6801,17 +6833,27 @@ bool Unit::IsImmuneToSpellEffect(SpellEntry const* spellInfo, SpellEffectIndex i
     return false;
 }
 
+uint32 Unit::MeleeDamageBonusDone(Unit* pVictim, uint32 pdamage, WeaponAttackType attType, SpellEntry const* spellProto, DamageEffectType damagetype, uint32 stack, Spell* spell, bool flat)
+{
+    Modifier m;
+    m.m_base = pdamage;
+    m.m_bonus = 0;
+    m.m_bonus_pct = 1;
+    MeleeDamageBonusDone(pVictim, &m, attType, spellProto, damagetype, stack, spell, flat);
+    int ret = m.total();
+    return ret > 0 ? ret : 0;
+}
 /**
  * Calculates caster part of melee damage bonuses,
  * also includes different bonuses dependent from target auras
  */
-uint32 Unit::MeleeDamageBonusDone(Unit* pVictim, uint32 pdamage, WeaponAttackType attType, SpellEntry const* spellProto, DamageEffectType damagetype, uint32 stack, Spell* spell, bool flat)
+void Unit::MeleeDamageBonusDone(Unit* pVictim, Modifier *pdamage, WeaponAttackType attType, SpellEntry const* spellProto, DamageEffectType damagetype, uint32 stack, Spell* spell, bool flat)
 {
     if (!pVictim)
-        return pdamage;
+        return;
 
-    if (pdamage == 0)
-        return pdamage;
+    if (pdamage->total() == 0)
+        return;
 
     // differentiate for weapon damage based spells
     bool isWeaponDamageBasedSpell = !(spellProto && (damagetype == DOT || IsSpellHaveEffect(spellProto, SPELL_EFFECT_SCHOOL_DAMAGE)));
@@ -6835,7 +6877,7 @@ uint32 Unit::MeleeDamageBonusDone(Unit* pVictim, uint32 pdamage, WeaponAttackTyp
                      spellProto->DmgClass == SPELL_DAMAGE_CLASS_RANGED) &&               // Some ranged physical attacks use magic damage, ex. Arcane Shot
                     (((*i)->GetSpellProto()->EquippedItemClass == -1) ||                     // general, weapon independent
                      (pWeapon && pWeapon->IsFitToSpellRequirements((*i)->GetSpellProto()))))  // OR used weapon fits aura requirements
-                DoneFlat += (*i)->GetModifier()->m_amount;
+                DoneFlat += (*i)->GetModifier()->total();
         }
 
         // Pets just add their bonus damage to their melee damage
@@ -6872,7 +6914,7 @@ uint32 Unit::MeleeDamageBonusDone(Unit* pVictim, uint32 pdamage, WeaponAttackTyp
                     (*i)->GetModifier()->m_miscvalue & GetMeleeDamageSchoolMask() &&         // AND schoolmask has to fit with weapon damage school (essential for non-physical spells)
                     (((*i)->GetSpellProto()->EquippedItemClass == -1) ||                     // general, weapon independent
                      (pWeapon && pWeapon->IsFitToSpellRequirements((*i)->GetSpellProto()))))  // OR used weapon fits aura requirements
-                DonePercent *= ((*i)->GetModifier()->m_amount + 100.0f) / 100.0f;
+                DonePercent *= ((*i)->GetModifier()->total() + 100.0f) / 100.0f;
         }
 
         if (attType == OFF_ATTACK)
@@ -6945,17 +6987,15 @@ uint32 Unit::MeleeDamageBonusDone(Unit* pVictim, uint32 pdamage, WeaponAttackTyp
     if (!flat)
         DoneTotal = 0.0f;
 
-    float tmpDamage = float(int32(pdamage) + DoneTotal * int32(stack)) * DonePercent;
+    pdamage->m_bonus +=  DoneTotal * stack;
+    pdamage->m_bonus_pct *= DonePercent;
 
     // apply spellmod to Done damage
     if (spellProto)
     {
         if (Player* modOwner = GetSpellModOwner())
-            modOwner->ApplySpellMod(spellProto->Id, damagetype == DOT ? SPELLMOD_DOT : SPELLMOD_DAMAGE, tmpDamage, spell);
+            modOwner->ApplySpellMod(spellProto->Id, damagetype == DOT ? SPELLMOD_DOT : SPELLMOD_DAMAGE, pdamage, spell);
     }
-
-    // bonus result can be negative
-    return tmpDamage > 0 ? uint32(tmpDamage) : 0;
 }
 
 /**
@@ -7590,15 +7630,15 @@ bool Unit::canDetectInvisibilityOf(Unit const* u) const
             int32 invLevel = 0;
             Unit::AuraList const& iAuras = u->GetAurasByType(SPELL_AURA_MOD_INVISIBILITY);
             for (Unit::AuraList::const_iterator itr = iAuras.begin(); itr != iAuras.end(); ++itr)
-                if ((*itr)->GetModifier()->m_miscvalue == i && invLevel < (*itr)->GetModifier()->m_amount)
-                    invLevel = (*itr)->GetModifier()->m_amount;
+                if ((*itr)->GetModifier()->m_miscvalue == i && invLevel < (*itr)->GetModifier()->total())
+                    invLevel = (*itr)->GetModifier()->total();
 
             // find invisibility detect level
             int32 detectLevel = 0;
             Unit::AuraList const& dAuras = GetAurasByType(SPELL_AURA_MOD_INVISIBILITY_DETECTION);
             for (Unit::AuraList::const_iterator itr = dAuras.begin(); itr != dAuras.end(); ++itr)
-                if ((*itr)->GetModifier()->m_miscvalue == i && detectLevel < (*itr)->GetModifier()->m_amount)
-                    detectLevel = (*itr)->GetModifier()->m_amount;
+                if ((*itr)->GetModifier()->m_miscvalue == i && detectLevel < (*itr)->GetModifier()->total())
+                    detectLevel = (*itr)->GetModifier()->total();
 
             if (i == 6 && GetTypeId() == TYPEID_PLAYER)     // special drunk detection case
                 detectLevel = ((Player*)this)->GetDrunkValue();

--- a/src/game/Objects/Unit.h
+++ b/src/game/Objects/Unit.h
@@ -1665,11 +1665,15 @@ class MANGOS_DLL_SPEC Unit : public WorldObject
         int32 SpellBaseDamageBonusDone(SpellSchoolMask schoolMask);
         int32 SpellBaseDamageBonusTaken(SpellSchoolMask schoolMask);
         uint32 SpellDamageBonusDone(Unit *pVictim, SpellEntry const *spellProto, uint32 pdamage, DamageEffectType damagetype, uint32 stack = 1, Spell* spell = nullptr);
+        void SpellDamageBonusDone(Unit *pVictim, SpellEntry const *spellProto, Modifier *pdamage, DamageEffectType damagetype, uint32 stack = 1, Spell* spell = nullptr);
         uint32 SpellDamageBonusTaken(Unit *pCaster, SpellEntry const *spellProto, uint32 pdamage, DamageEffectType damagetype, uint32 stack = 1, Spell* spell = nullptr);
         int32 SpellBaseHealingBonusDone(SpellSchoolMask schoolMask);
         int32 SpellBaseHealingBonusTaken(SpellSchoolMask schoolMask);
+        void SpellHealingBonusDone(Unit *pVictim, SpellEntry const *spellProto, Modifier *healamount, DamageEffectType damagetype, uint32 stack = 1, Spell* spell = nullptr);
         uint32 SpellHealingBonusDone(Unit *pVictim, SpellEntry const *spellProto, int32 healamount, DamageEffectType damagetype, uint32 stack = 1, Spell* spell = nullptr);
         uint32 SpellHealingBonusTaken(Unit *pCaster, SpellEntry const *spellProto, int32 healamount, DamageEffectType damagetype, uint32 stack = 1, Spell* spell = nullptr);
+        void MeleeDamageBonusDone(Unit *pVictim, Modifier *damage, WeaponAttackType attType,
+            SpellEntry const *spellProto = nullptr, DamageEffectType damagetype = DIRECT_DAMAGE, uint32 stack = 1, Spell* spell = nullptr, bool flat = true);
         uint32 MeleeDamageBonusDone(Unit *pVictim, uint32 damage, WeaponAttackType attType,
             SpellEntry const *spellProto = nullptr, DamageEffectType damagetype = DIRECT_DAMAGE, uint32 stack = 1, Spell* spell = nullptr, bool flat = true);
         uint32 MeleeDamageBonusTaken(Unit *pCaster, uint32 pdamage,WeaponAttackType attType,

--- a/src/game/Spells/SpellAuras.cpp
+++ b/src/game/Spells/SpellAuras.cpp
@@ -1465,7 +1465,7 @@ void Aura::HandleAuraDummy(bool apply, bool Real)
                                 if (!player->InBattleGround())
                                     player->RemoveAurasDueToSpell(2584);
                         }
-                        return;                            
+                        return;
                     }
                     case 10255:                             // Stoned
                     {
@@ -4756,7 +4756,7 @@ void Aura::HandleAuraGhost(bool apply, bool /*Real*/)
         GetTarget()->SetFlag(PLAYER_FLAGS, PLAYER_FLAGS_GHOST);
     else
         GetTarget()->RemoveFlag(PLAYER_FLAGS, PLAYER_FLAGS_GHOST);
-    
+
     if (((Player*)GetTarget())->GetGroup())
         ((Player*)GetTarget())->SetGroupUpdateFlag(GROUP_UPDATE_FLAG_STATUS);
 }
@@ -4935,7 +4935,7 @@ void Aura::PeriodicTick(SpellEntry const* sProto, AuraType auraType, uint32 data
                 if (m_modifier.m_auraname == SPELL_AURA_PERIODIC_DAMAGE)
                     pdamage = amount;
                 else
-                    pdamage = uint32(target->GetMaxHealth() * amount / 100);                
+                    pdamage = uint32(target->GetMaxHealth() * amount / 100);
             }
 
             // SpellDamageBonus for magic spells
@@ -4956,6 +4956,9 @@ void Aura::PeriodicTick(SpellEntry const* sProto, AuraType auraType, uint32 data
                 cleanDamage.damage += pdamage - pdamageReductedArmor;
                 pdamage = pdamageReductedArmor;
             }
+
+            // TODO (Curse of Agony/Starshards):
+            // only base damage should be affected, not whole damage
 
             // Curse of Agony damage-per-tick calculation
             if (spellProto->IsFitToFamily<SPELLFAMILY_WARLOCK, CF_WARLOCK_CURSE_OF_AGONY>())
@@ -5947,15 +5950,15 @@ bool SpellAuraHolder::IsNeedVisibleSlot(Unit const* caster) const
     // up a slot
     bool persistent = m_spellProto->Effect[EFFECT_INDEX_0] == SPELL_EFFECT_PERSISTENT_AREA_AURA;
     bool persistentWithSecondaryEffect = false;
-    
+
     for (int i = 0; i < MAX_EFFECT_INDEX; ++i)
     {
-        // Check for persistent aura here since the effect aura is applied to the holder 
-        // by a dynamic object as the target passes through the object field, meaning 
+        // Check for persistent aura here since the effect aura is applied to the holder
+        // by a dynamic object as the target passes through the object field, meaning
         // m_auras will be unset when this method is called (initialization)
         if (!m_auras[i] && !persistent)
             continue;
-            
+
         // special area auras cases
         switch (m_spellProto->Effect[i])
         {
@@ -5963,14 +5966,14 @@ bool SpellAuraHolder::IsNeedVisibleSlot(Unit const* caster) const
             case SPELL_EFFECT_APPLY_AREA_AURA_PARTY:
                 // passive auras (except totem auras) do not get placed in caster slot
                 return (m_target != caster || totemAura || !m_isPassive) && m_auras[i]->GetModifier()->m_auraname != SPELL_AURA_NONE;
-                
+
                 break;
             case SPELL_EFFECT_PERSISTENT_AREA_AURA:
                 // If spell aura applies something other than plain damage, it takes
                 // up a debuff slot.
                 if (m_spellProto->EffectApplyAuraName[i] != SPELL_AURA_PERIODIC_DAMAGE)
                     persistentWithSecondaryEffect = true;
-                    
+
                 break;
             default:
                 break;
@@ -5980,10 +5983,10 @@ bool SpellAuraHolder::IsNeedVisibleSlot(Unit const* caster) const
     /*  Persistent area auras such as Blizzard/RoF/Volley do not get require debuff slots
         since they just do area damage with no additional effects. However, spells like
         Hurricane do since they have a secondary effect attached to them. There are enough
-        persistent area spells in-game that making a switch for all of them is a bit 
+        persistent area spells in-game that making a switch for all of them is a bit
         unreasonable. Any spell with a secondary affect should take up a slot. Note
         that most (usable) persistent spells only deal damage.
-        
+
         It was considered whether spells with secondary effects should still deal damage,
         even if there is no room for the other effect, however the debuff tooltip states
         that the spell causes damage AND slows, therefore it must take a debuff slot.
@@ -5992,7 +5995,7 @@ bool SpellAuraHolder::IsNeedVisibleSlot(Unit const* caster) const
     {
         return false;
     }
-    
+
     // necessary for some spells, e.g. Immolate visual passive 28330
     if (m_spellProto->SpellVisual)
         return true;
@@ -6413,7 +6416,7 @@ void SpellAuraHolder::CalculateForDebuffLimit()
                 // Hakkar's Blood Siphon
                 case 24323:
                 case 24322:
-                    m_debuffLimitScore = 4; 
+                    m_debuffLimitScore = 4;
                     return;
             }
         }

--- a/src/game/Spells/SpellAuras.cpp
+++ b/src/game/Spells/SpellAuras.cpp
@@ -4970,8 +4970,8 @@ void Aura::PeriodicTick(SpellEntry const* sProto, AuraType auraType, uint32 data
             }
             if (spellProto->IsFitToFamily<SPELLFAMILY_PRIEST, CF_PRIEST_STARSHARDS>())
             {
-                //ticks: .12/.12/.165/.165/.215/.215
-                float ticks[] = {0,.12,.24,.405,.57,.785,1};
+                //ticks: 2/3, 2/3, 1, 1, 4/3, 4/3
+                float ticks[] = {0,.111,.222,.389,.556,.778,1};
                 float dmg = ticks[GetAuraTicks() -1];
                 float ddone = ticks[GetAuraTicks()];
                 pdamage *= 6;

--- a/src/game/Spells/SpellAuras.cpp
+++ b/src/game/Spells/SpellAuras.cpp
@@ -4968,6 +4968,16 @@ void Aura::PeriodicTick(SpellEntry const* sProto, AuraType auraType, uint32 data
                     pdamage += (pdamage + 1) / 2;       // +1 prevent 0.5 damage possible lost at 1..4 ticks
                 // 5..8 ticks have normal tick damage
             }
+            if (spellProto->IsFitToFamily<SPELLFAMILY_PRIEST, CF_PRIEST_STARSHARDS>())
+            {
+                //ticks: .12/.12/.165/.165/.215/.215
+                float ticks[] = {0,.12,.24,.405,.57,.785,1};
+                float dmg = ticks[GetAuraTicks() -1];
+                float ddone = ticks[GetAuraTicks()];
+                pdamage *= 6;
+                pdamage = std::round(pdamage * ddone - pdamage * dmg);
+            }
+
 
             target->CalculateDamageAbsorbAndResist(pCaster, GetSpellSchoolMask(spellProto), DOT, pdamage, &absorb, &resist, spellProto);
 

--- a/src/game/Spells/SpellAuras.cpp
+++ b/src/game/Spells/SpellAuras.cpp
@@ -4975,7 +4975,7 @@ void Aura::PeriodicTick(SpellEntry const* sProto, AuraType auraType, uint32 data
                 float dmg = ticks[GetAuraTicks() -1];
                 float ddone = ticks[GetAuraTicks()];
                 pdamage *= 6;
-                pdamage = std::round(pdamage * ddone - pdamage * dmg);
+                pdamage = std::round(std::round(pdamage * ddone) - pdamage * dmg);
             }
 
 

--- a/src/game/Spells/SpellAuras.h
+++ b/src/game/Spells/SpellAuras.h
@@ -29,9 +29,15 @@
 struct Modifier
 {
     AuraType m_auraname;
-    int32 m_amount;
+    int32 m_base;
+    int32 m_bonus;
+    float m_bonus_pct;
+    int32 m_used;
     int32 m_miscvalue;
     uint32 periodictime;
+
+    int32 total(float base_coeff=1) const { return std::round((m_base * base_coeff + m_bonus) * m_bonus_pct); }
+    int32 remaning() const { return total() - m_used; }
 };
 
 struct HeartBeatData
@@ -414,9 +420,12 @@ class MANGOS_DLL_SPEC Aura
         uint32 GetStackAmount() const { return GetHolder()->GetStackAmount(); }
 
         void CalculatePeriodic(Player * modOwner, bool create);
-        void SetLoadedState(int32 damage, uint32 periodicTime)
+        void SetLoadedState(int32 base, int32 bonus, float pct, int32 used, uint32 periodicTime)
         {
-            m_modifier.m_amount = damage;
+            m_modifier.m_base = base;
+            m_modifier.m_bonus = bonus;
+            m_modifier.m_bonus_pct = pct;
+            m_modifier.m_used = used;
             m_modifier.periodictime = periodicTime;
 
             if(uint32 maxticks = GetAuraMaxTicks())

--- a/src/game/Spells/SpellEffects.cpp
+++ b/src/game/Spells/SpellEffects.cpp
@@ -1494,7 +1494,7 @@ void Spell::EffectDummy(SpellEffectIndex eff_idx)
                     {
                         // only Imp. Life Tap have this in combination with dummy aura
                         if ((*itr)->GetSpellProto()->SpellFamilyName == SPELLFAMILY_WARLOCK && (*itr)->GetSpellProto()->SpellIconID == 208)
-                            mana = ((*itr)->GetModifier()->m_amount + 100) * mana / 100;
+                            mana = ((*itr)->GetModifier()->total() + 100) * mana / 100;
                     }
 
                     m_caster->CastCustomSpell(m_caster, 31818, &mana, nullptr, nullptr, true, nullptr);
@@ -2217,7 +2217,7 @@ void Spell::EffectHeal(SpellEffectIndex /*eff_idx*/)
                 idx++;
             }
 
-            int32 tickheal = targetAura->GetModifier()->m_amount;
+            int32 tickheal = targetAura->GetModifier()->total();
             int32 tickcount = 0;
             // Regrowth : 0x40
             // "18 sec of Regrowth" -> 6 ticks
@@ -3967,7 +3967,7 @@ void Spell::EffectHealMaxHealth(SpellEffectIndex /*eff_idx*/)
     // Healing done percent
     std::list <Aura*> const& mHealingDonePct = m_caster->GetAurasByType(SPELL_AURA_MOD_HEALING_DONE_PERCENT);
     for (std::list <Aura*>::const_iterator i = mHealingDonePct.begin(); i != mHealingDonePct.end(); ++i)
-        DoneTotalMod *= (100.0f + (*i)->GetModifier()->m_amount) / 100.0f;
+        DoneTotalMod *= (100.0f + (*i)->GetModifier()->total()) / 100.0f;
 
     heal *= DoneTotalMod;
 

--- a/src/game/StatSystem.cpp
+++ b/src/game/StatSystem.cpp
@@ -141,7 +141,7 @@ void Player::UpdateArmor()
     {
         Modifier* mod = (*i)->GetModifier();
         if (mod->m_miscvalue & SPELL_SCHOOL_MASK_NORMAL)
-            value += int32(GetStat(STAT_INTELLECT) * mod->m_amount / 100.0f);
+            value += int32(GetStat(STAT_INTELLECT) * mod->total() / 100.0f);
     }
 
     // add dummy effects from spells (check class and other conditions first for optimization)
@@ -158,7 +158,7 @@ void Player::UpdateArmor()
                 {
                     float enrageModifier = 0.0f;
                     enrageModifier = GetModifierValue(unitMod, BASE_VALUE);
-                    enrageModifier *= (*itr)->GetModifier()->m_amount / 100.0f;
+                    enrageModifier *= (*itr)->GetModifier()->total() / 100.0f;
                     value += enrageModifier;
                     break;
                 }
@@ -303,7 +303,7 @@ void Player::UpdateAttackPowerAndDamage(bool ranged)
                             // Predatory Strikes
                             if ((*itr)->GetSpellProto()->SpellIconID == 1563)
                             {
-                                mLevelMult = (*itr)->GetModifier()->m_amount / 100.0f;
+                                mLevelMult = (*itr)->GetModifier()->total() / 100.0f;
                                 break;
                             }
                         }

--- a/src/game/UnitAuraProcHandler.cpp
+++ b/src/game/UnitAuraProcHandler.cpp
@@ -412,7 +412,7 @@ SpellAuraProcResult Unit::HandleHasteAuraProc(Unit *pVictim, uint32 damage, Aura
 SpellAuraProcResult Unit::HandleDummyAuraProc(Unit *pVictim, uint32 damage, Aura* triggeredByAura, SpellEntry const * procSpell, uint32 procFlag, uint32 procEx, uint32 cooldown)
 {
     SpellEntry const *dummySpell = triggeredByAura->GetSpellProto();
-    int32  triggerAmount = triggeredByAura->GetModifier()->m_amount;
+    int32  triggerAmount = triggeredByAura->GetModifier()->total();
 
     Item* castItem = triggeredByAura->GetCastItemGuid() && GetTypeId() == TYPEID_PLAYER
                      ? ((Player*)this)->GetItemByGuid(triggeredByAura->GetCastItemGuid()) : NULL;
@@ -525,8 +525,8 @@ SpellAuraProcResult Unit::HandleDummyAuraProc(Unit *pVictim, uint32 damage, Aura
 
                     if (GetSchoolMask(procSpell->School) == SPELL_SCHOOL_MASK_FROST)
                     {
-                        ++triggeredByAura->GetModifier()->m_amount;
-                        triggerAmount = triggeredByAura->GetModifier()->m_amount;
+                        ++triggeredByAura->GetModifier()->total();
+                        triggerAmount = triggeredByAura->GetModifier()->total();
 
                         if (triggerAmount == 100)
                             triggered_spell_id = 26034; // Slowed
@@ -549,8 +549,8 @@ SpellAuraProcResult Unit::HandleDummyAuraProc(Unit *pVictim, uint32 damage, Aura
                             return SPELL_AURA_PROC_FAILED;
                     }
 
-                    ++triggeredByAura->GetModifier()->m_amount;
-                    triggerAmount = triggeredByAura->GetModifier()->m_amount;
+                    ++triggeredByAura->GetModifier()->m_base;
+                    triggerAmount = triggeredByAura->GetModifier()->total();
 
                     if (triggerAmount == 50)
                         MonsterTextEmote(-1531044, NULL); // Cracks
@@ -722,7 +722,7 @@ SpellAuraProcResult Unit::HandleDummyAuraProc(Unit *pVictim, uint32 damage, Aura
                         Modifier *igniteModifier = igniteAura->GetModifier();
                         SpellAuraHolder* igniteHolder = igniteAura->GetHolder();
                         
-                        int32 tickDamage = igniteModifier->m_amount;
+                        int32 tickDamage = igniteModifier->m_base;
                         
                         bool notAtMaxStack = igniteAura->GetStackAmount() < 5;
                         
@@ -737,7 +737,7 @@ SpellAuraProcResult Unit::HandleDummyAuraProc(Unit *pVictim, uint32 damage, Aura
                                 igniteHolder->ModStackAmount(1);
                                 
                                 // Update DOT damage
-                                igniteModifier->m_amount = tickDamage;
+                                igniteModifier->m_base = tickDamage;
                                 igniteAura->ApplyModifier(true, true, false);
                             }
                             else
@@ -1099,7 +1099,7 @@ SpellAuraProcResult Unit::HandleProcTriggerSpellAuraProc(Unit *pVictim, uint32 d
     SpellEntry const* auraSpellInfo = triggeredByAura->GetSpellProto();
 
     // Basepoints of trigger aura
-    int32 triggerAmount = triggeredByAura->GetModifier()->m_amount;
+    int32 triggerAmount = triggeredByAura->GetModifier()->total();
 
     // Set trigger spell id, target, custom basepoints
     uint32 trigger_spell_id = auraSpellInfo->EffectTriggerSpell[triggeredByAura->GetEffIndex()];
@@ -1492,9 +1492,9 @@ SpellAuraProcResult Unit::HandleProcTriggerDamageAuraProc(Unit *pVictim, uint32 
 {
     SpellEntry const *spellInfo = triggeredByAura->GetSpellProto();
     DEBUG_FILTER_LOG(LOG_FILTER_SPELL_CAST, "ProcDamageAndSpell: doing %u damage from spell id %u (triggered by auratype %u of spell %u)",
-                     triggeredByAura->GetModifier()->m_amount, spellInfo->Id, triggeredByAura->GetModifier()->m_auraname, triggeredByAura->GetId());
+                     triggeredByAura->GetModifier()->total(), spellInfo->Id, triggeredByAura->GetModifier()->m_auraname, triggeredByAura->GetId());
     SpellNonMeleeDamage damageInfo(this, pVictim, spellInfo->Id, SpellSchools(spellInfo->School));
-    CalculateSpellDamage(&damageInfo, triggeredByAura->GetModifier()->m_amount, spellInfo);
+    CalculateSpellDamage(&damageInfo, triggeredByAura->GetModifier()->total(), spellInfo);
     damageInfo.target->CalculateAbsorbResistBlock(this, &damageInfo, spellInfo);
     DealDamageMods(damageInfo.target, damageInfo.damage, &damageInfo.absorb);
     SendSpellNonMeleeDamageLog(&damageInfo);
@@ -1513,7 +1513,7 @@ SpellAuraProcResult Unit::HandleOverrideClassScriptAuraProc(Unit *pVictim, uint3
                      ? ((Player*)this)->GetItemByGuid(triggeredByAura->GetCastItemGuid()) : NULL;
 
     // Basepoints of trigger aura
-    int32 triggerAmount = triggeredByAura->GetModifier()->m_amount;
+    int32 triggerAmount = triggeredByAura->GetModifier()->total();
 
     uint32 triggered_spell_id = 0;
 


### PR DESCRIPTION
Starshards and Curse of Agony change their base damage over time, but spell power bonus is the same for every tick.
To achieve that, we can't store total damage at cast time, but we have to store base damage and bonuses separately for later calculation.

### Coefficients
[starshards.xlsx](https://github.com/elysium-project/server/files/1100416/starshards.xlsx)
- Starshards samples are from early TBC videos
- CoA samples are from Vanilla videos

### Implementation Details
instead of the total damage,
Modifier now stores:

 Member     |  purpose
------------|-----------------------------------------------------------------------
m_base      | base points (e.g. damage) of the aura
m_bonus     | flat addition (e.g. spell power)
m_bonus_pct | percentage bonuses (e.g. talents +x% bonus damage)
m_used      | currently for shields assorbed damage (e.g. Power Word: Shield)
total(c)    | return value calculating bonuses (m_base * c + m_bonus) * m_bonus_pct
remaning()  | return total() - m_used, currently used for remaning shields value

pet_aura and character_aura table have been updated to store such data as well.