### PR TITLE
Core/Misc: Fix current player state when logging out

### DIFF
--- a/src/game/Handlers/MiscHandler.cpp
+++ b/src/game/Handlers/MiscHandler.cpp
@@ -329,7 +329,7 @@ void WorldSession::HandleLogoutRequestOpcode(WorldPacket & /*recv_data*/)
     if (GetPlayer()->CanFreeMove())
     {
         float height = GetPlayer()->GetMap()->GetHeight(GetPlayer()->GetPositionX(), GetPlayer()->GetPositionY(), GetPlayer()->GetPositionZ());
-        if ((GetPlayer()->GetPositionZ() < height + 0.1f) && !(GetPlayer()->IsInWater()))
+        if ((GetPlayer()->GetPositionZ() < height + 0.1f) && !(GetPlayer()->IsInWater()) && GetPlayer()->getStandState() == UNIT_STAND_STATE_STAND)
             GetPlayer()->SetStandState(UNIT_STAND_STATE_SIT);
 
         GetPlayer()->SetMovement(MOVE_ROOT);


### PR DESCRIPTION
Sit should only be apply'd when player is standing.
For example when sitting on a chair when logging out, player should stay on the chair until fully logged out and not sit on the floor.

https://github.com/TrinityCore/TrinityCore/commit/a96ff6043d62ba7afd4689c922e6fee734afc415