### PR TITLE
Set required level for quest "In Search of Thaelrid" to 18 (#1162)

### DIFF
--- a/sql/migrations/20170628103600_world.sql
+++ b/sql/migrations/20170628103600_world.sql
@@ -1,0 +1,4 @@
+INSERT INTO `migrations` VALUES ('20170628103600'); 
+
+-- Set required level for quest "In Search of Thaelrid" to 18
+UPDATE quest_template SET MinLevel = 18 WHERE entry = 1198;


### PR DESCRIPTION
See https://elysium-project.org/bugtracker/issue/2491 (from 20 down to 18)

Fixes #1162