### PR TITLE
Misc Fixes for Flight Master NPCs

### DIFF
--- a/src/game/GossipDef.cpp
+++ b/src/game/GossipDef.cpp
@@ -31,6 +31,7 @@ GossipMenu::GossipMenu(WorldSession* session) : m_session(session)
 {
     m_gItems.reserve(16);                                   // can be set for max from most often sizes to speedup push_back and less memory use
     m_gMenuId = 0;
+    m_discoveredNode = false;
 }
 
 GossipMenu::~GossipMenu()
@@ -119,6 +120,7 @@ void GossipMenu::ClearMenu()
     m_gItems.clear();
     m_gItemsData.clear();
     m_gMenuId = 0;
+    m_discoveredNode = false;
 }
 
 PlayerMenu::PlayerMenu(WorldSession *session) : mGossipMenu(session)

--- a/src/game/GossipDef.h
+++ b/src/game/GossipDef.h
@@ -173,6 +173,10 @@ class MANGOS_DLL_SPEC GossipMenu
         void SetMenuId(uint32 menu_id) { m_gMenuId = menu_id; }
         uint32 GetMenuId() { return m_gMenuId; }
 
+        // used to avoid opening gossip menu at node discover
+        void SetDiscoveredNode() { m_discoveredNode = true; }
+        bool IsJustDiscoveredNode() { return m_discoveredNode; }
+
         void AddGossipMenuItemData(int32 action_menu, uint32 action_poi, uint32 action_script);
 
         unsigned int MenuItemCount() const
@@ -208,6 +212,7 @@ class MANGOS_DLL_SPEC GossipMenu
         GossipMenuItemDataList  m_gItemsData;
 
         uint32 m_gMenuId;
+        bool m_discoveredNode;
 
     private:
         WorldSession* m_session;

--- a/src/game/Objects/Object.cpp
+++ b/src/game/Objects/Object.cpp
@@ -559,6 +559,31 @@ void Object::BuildValuesUpdate(uint8 updatetype, ByteBuffer * data, UpdateMask *
                             if (target->getClass() != CLASS_HUNTER)
                                 appendValue &= ~UNIT_NPC_FLAG_STABLEMASTER;
                         }
+
+                        if (appendValue & UNIT_NPC_FLAG_FLIGHTMASTER)
+                        {
+                            QuestRelationsMapBounds bounds = sObjectMgr.GetCreatureQuestRelationsMapBounds(((Creature*)this)->GetEntry());
+                            for (QuestRelationsMap::const_iterator itr = bounds.first; itr != bounds.second; ++itr)
+                            {
+                                Quest const* pQuest = sObjectMgr.GetQuestTemplate(itr->second);
+                                if (target->CanSeeStartQuest(pQuest))
+                                {
+                                    appendValue &= ~UNIT_NPC_FLAG_FLIGHTMASTER;
+                                    break;
+                                }
+                            }
+
+                            bounds = sObjectMgr.GetCreatureQuestInvolvedRelationsMapBounds(((Creature*)this)->GetEntry());
+                            for (QuestRelationsMap::const_iterator itr = bounds.first; itr != bounds.second; ++itr)
+                            {
+                                Quest const* pQuest = sObjectMgr.GetQuestTemplate(itr->second);
+                                if (target->CanRewardQuest(pQuest, false))
+                                {
+                                    appendValue &= ~UNIT_NPC_FLAG_FLIGHTMASTER;
+                                    break;
+                                }
+                            }
+                        }
                     }
 
                     *data << uint32(appendValue);


### PR DESCRIPTION
- Don't show the gossip menu when learning a flight path.

- Show an exclamation icon above flight masters that are offering a quest.

Credit for these fixes goes to cmangos.
https://github.com/cmangos/mangos-classic/commit/197e610c80b011e046c677a2a0c58739728ed19a
https://github.com/cmangos/mangos-classic/commit/77b64ebe0360ddf809eeca2485bce0f71a49adc5