### PR TITLE
Evergreen Pouch (ID: 11020) corrections

### DIFF
--- a/sql/migrations/20170701194500_world.sql
+++ b/sql/migrations/20170701194500_world.sql
@@ -1,0 +1,4 @@
+INSERT INTO `migrations` VALUES ('20170701194500'); 
+
+-- Set RequiredLevel for Evergreen Pouch (ID: 11020) to 57:
+UPDATE item_template SET RequiredLevel = 0 WHERE entry = 11020;

--- a/sql/migrations/20170701194500_world.sql
+++ b/sql/migrations/20170701194500_world.sql
@@ -1,4 +1,4 @@
 INSERT INTO `migrations` VALUES ('20170701194500'); 
 
--- Set RequiredLevel for Evergreen Pouch (ID: 11020) to 57:
+-- Set RequiredLevel for Evergreen Pouch (ID: 11020) to 0:
 UPDATE item_template SET RequiredLevel = 0 WHERE entry = 11020;


### PR DESCRIPTION
Evergreen Pouch (ID: 11020)

Set RequiredLevel to 0 instead of 47.

This were at 0 in vanilla. Nostralius changed this to 47. I dont know why, see
https://forum.nostalrius.org/viewtopic.php?f=2&t=31252