### PR TITLE
Hurricane (ID: 2824) corrections

### DIFF
--- a/sql/migrations/20170704134500_world.sql
+++ b/sql/migrations/20170704134500_world.sql
@@ -1,0 +1,6 @@
+INSERT INTO `migrations` VALUES ('20170704134500'); 
+
+-- Set BuyPrice for Hurricane (ID: 2824) to 16g 1s 59c:
+UPDATE item_template SET BuyPrice = 160159 WHERE entry = 2824;
+-- Set SellPrice for Hurricane (ID: 2824) to 3g 20s 31c:
+UPDATE item_template SET SellPrice = 32031 WHERE entry = 2824;


### PR DESCRIPTION
Hurricane (ID: 2824)

BuyPrice/SellPrice should be 160159/32031 instead of 160160/32032

I found a lot of items with one copper price difference. Any idea why?

Source:
http://www0.xup.in/exec/ximg.php?fid=66640670 (BradyGames Official Strategy Guide)
https://web.archive.org/web/20050227011012/http://wow.allakhazam.com:80/db/item.html?witem=2824