### PR TITLE
Improvements for RFD escort ritual

### DIFF
--- a/src/scripts/kalimdor/the_barrens/razorfen_downs/instance_razorfen_downs.cpp
+++ b/src/scripts/kalimdor/the_barrens/razorfen_downs/instance_razorfen_downs.cpp
@@ -29,6 +29,8 @@ struct instance_razorfen_downs : public ScriptedInstance
     };
 
     uint64 uiGongGUID;
+    uint64 uiCupFire1GUID;
+    uint64 uiCupFire2GUID;
 
     uint32 m_auiEncounter[MAX_ENCOUNTER];
 
@@ -40,6 +42,10 @@ struct instance_razorfen_downs : public ScriptedInstance
     void Initialize()
     {
         uiGongGUID = 0;
+
+        uiCupFire1GUID = 0;
+
+        uiCupFire2GUID = 0;
 
         uiGongWaves = 0;
 
@@ -75,6 +81,12 @@ struct instance_razorfen_downs : public ScriptedInstance
                 uiGongGUID = pGo->GetGUID();
                 if (m_auiEncounter[0] == DONE)
                     pGo->SetFlag(GAMEOBJECT_FLAGS, GO_FLAG_NO_INTERACT);
+                break;
+            case GO_IDOL_CUP_FIRE:
+                if (uiCupFire1GUID != 0)
+                    uiCupFire2GUID = pGo->GetGUID();
+                else
+                    uiCupFire1GUID = pGo->GetGUID();
                 break;
             default:
                 break;
@@ -166,6 +178,14 @@ struct instance_razorfen_downs : public ScriptedInstance
 
             if (uiData == DONE)
                 SaveToDB();
+        }
+
+        if (uiType == EXTINGUISH_FIRES)
+        {
+            if (GameObject* pGoCupFire1 = instance->GetGameObject(uiCupFire1GUID))
+                pGoCupFire1->SetLootState(GO_JUST_DEACTIVATED);
+            if (GameObject* pGoCupFire2 = instance->GetGameObject(uiCupFire2GUID))
+                pGoCupFire2->SetLootState(GO_JUST_DEACTIVATED);
         }
 
         if (uiData == DONE)

--- a/src/scripts/kalimdor/the_barrens/razorfen_downs/razorfen_downs.h
+++ b/src/scripts/kalimdor/the_barrens/razorfen_downs/razorfen_downs.h
@@ -22,7 +22,8 @@
 enum eData
 {
     BOSS_TUTEN_KASH,
-    DATA_GONG_WAVES
+    DATA_GONG_WAVES,
+    EXTINGUISH_FIRES
 };
 
 enum eData64
@@ -32,7 +33,8 @@ enum eData64
 
 enum eGameObject
 {
-        GO_GONG                                                                         = 148917
+    GO_GONG                                     = 148917,
+    GO_IDOL_CUP_FIRE                            = 151952
 };
 
 enum eCreature


### PR DESCRIPTION
Small improvements for the escort ritual in Razorfen Downs.

- Belnistrasz will no longer turn around while channeling.

- The idol fires will be properly extinguished upon completion of the ritual.