### PR TITLE
add missing entry for openssl include dir

### DIFF
--- a/src/realmd/CMakeLists.txt
+++ b/src/realmd/CMakeLists.txt
@@ -46,6 +46,7 @@ include_directories(
   ${CMAKE_BINARY_DIR}/src/shared
   ${MYSQL_INCLUDE_DIR}
   ${ACE_INCLUDE_DIR}
+  ${OPENSSL_INCLUDE_DIR}
 )
 
 add_executable(${EXECUTABLE_NAME}


### PR DESCRIPTION
Fix cmake ignoring `OPENSSL_INCLUDE_DIR`.