### PR TITLE
Fix: Multiple Ranks of JoW/JoL on single target

### DIFF
--- a/src/game/Spells/SpellMgr.cpp
+++ b/src/game/Spells/SpellMgr.cpp
@@ -596,6 +596,7 @@ bool IsSingleFromSpellSpecificSpellRanksPerTarget(SpellSpecific spellSpec1, Spel
         case SPELL_AURA:
         case SPELL_CURSE:
         case SPELL_ASPECT:
+        case SPELL_JUDGEMENT:
             return spellSpec1 == spellSpec2;
         default:
             return false;


### PR DESCRIPTION
I am unsure if this one line will fix the issue entirely, but I added this line (and others to different branches) to hopefully fix the current issue with the Paladin's Judgement ability. Currently, Paladins are the only class able to stack multiple different ranks of the same ability on a single target, e.g. three different paladins in the same group can judge a single boss with three separate ranks of Seal of Light/Seal of Wisdom. This not only has obvious consequences for imbalanced gameplay, but also defies Blizzard's apparent rules regarding this game mechanic: abilities like Sunder Armor, Judgement of Light, Judgement of Wisdom, Curse of Weakness, etc. should not be able to stack on a single target, AND furthermore different ranks of these abilities should also not be able to stack on a single target.