### PR TITLE
fix Warsong Gulch flags respawn

### DIFF
--- a/src/game/Battlegrounds/BattleGround.cpp
+++ b/src/game/Battlegrounds/BattleGround.cpp
@@ -1463,6 +1463,8 @@ void BattleGround::SpawnBGObject(ObjectGuid guid, uint32 respawntime)
         if (obj->GetEntry() == 178786 || obj->GetEntry() == 178787 || obj->GetEntry() == 178788 || obj->GetEntry() == 178789)
             obj->SetRespawnDelay(60);
 
+        if (!obj->GetRespawnTime())
+            map->Add(obj);
     }
     else
     {


### PR DESCRIPTION
`Add` is not called when respawn time is set to 0.