### PR TITLE
Fix for ffa mode

### DIFF
--- a/src/game/Objects/Player.cpp
+++ b/src/game/Objects/Player.cpp
@@ -1208,7 +1208,7 @@ void Player::Update(uint32 update_diff, uint32 p_time)
         if (pVictim && !IsNonMeleeSpellCasted(false))
         {
             Player *vOwner = pVictim->GetCharmerOrOwnerPlayerOrPlayerItself();
-            if (vOwner && vOwner->IsPvP() && !IsInDuelWith(vOwner))
+            if (vOwner && vOwner->IsPvP() && !IsInDuelWith(vOwner) && (!IsFFAPvP() || !vOwner->IsFFAPvP()))
             {
                 UpdatePvP(true);
                 RemoveAurasWithInterruptFlags(AURA_INTERRUPT_FLAG_ENTER_PVP_COMBAT);
@@ -16179,12 +16179,35 @@ void Player::UpdatePvPFlag(time_t currTime)
     UpdatePvP(false);
 }
 
+struct SetFFAPvPHelper
+{
+    explicit SetFFAPvPHelper(Unit* _source) : source(_source) {}
+    void operator()(Unit* unit) const
+    {
+        // the unit could still be attacking, stop if needed
+        Unit* victim = unit->getVictim();
+        if (victim && !unit->IsValidAttackTarget(victim))
+            unit->AttackStop();
+        // or be attacked
+        for (Unit* attacker : unit->getAttackers())
+            if (!attacker->IsValidAttackTarget(unit))
+                attacker->AttackStop();
+    }
+    Unit* source;
+};
+
 void Player::SetFFAPvP(bool state)
 {
     if (state)
         SetFlag(PLAYER_FLAGS, PLAYER_FLAGS_FFA_PVP);
     else
+    {
         RemoveFlag(PLAYER_FLAGS, PLAYER_FLAGS_FFA_PVP);
+
+        SetFFAPvPHelper ffaUpdateHelper(this);
+        ffaUpdateHelper(this);
+        CallForAllControlledUnits(ffaUpdateHelper, CONTROLLED_PET | CONTROLLED_GUARDIANS | CONTROLLED_CHARM | CONTROLLED_TOTEMS);
+    }
 
     if (GetGroup())
         SetGroupUpdateFlag(GROUP_UPDATE_FLAG_STATUS);

--- a/src/game/Objects/Unit.cpp
+++ b/src/game/Objects/Unit.cpp
@@ -7352,8 +7352,8 @@ bool Unit::_IsValidAttackTarget(Unit const* target, SpellEntry const* bySpell, W
         if (playerAffectingTarget->IsPvP())
             return true;
 
-        if (playerAffectingAttacker->GetByteValue(UNIT_FIELD_BYTES_2, 1) & UNIT_BYTE2_FLAG_FFA_PVP
-                && playerAffectingTarget->GetByteValue(UNIT_FIELD_BYTES_2, 1) & UNIT_BYTE2_FLAG_FFA_PVP)
+        // UNIT_BYTE2_FLAG_FFA_PVP is not implemented
+        if (playerAffectingAttacker->IsFFAPvP() && playerAffectingTarget->IsFFAPvP())
             return true;
 
         return (playerAffectingAttacker->GetByteValue(UNIT_FIELD_BYTES_2, 1) & UNIT_BYTE2_FLAG_UNK1)

--- a/src/game/Spells/Spell.cpp
+++ b/src/game/Spells/Spell.cpp
@@ -602,7 +602,7 @@ void Spell::FillTargetMap()
             for (UnitList::const_iterator itr = tmpUnitMap.begin(); itr != tmpUnitMap.end(); ++itr)
             {
                 Player *targetOwner = (*itr)->GetCharmerOrOwnerPlayerOrPlayerItself();
-                if (targetOwner && targetOwner != me && targetOwner->IsPvP() && !me->IsInDuelWith(targetOwner))
+                if (targetOwner && targetOwner != me && targetOwner->IsPvP() && !me->IsInDuelWith(targetOwner) && (!me->IsFFAPvP() || !targetOwner->IsFFAPvP()))
                 {
                     me->UpdatePvP(true);
                     me->RemoveAurasWithInterruptFlags(AURA_INTERRUPT_FLAG_ENTER_PVP_COMBAT);


### PR DESCRIPTION
Players and pets stop attacks if needed when exiting a ffa arena. Fix #1718
Fix an issue mentioned in #922 : on normal server players can't use spell in ffa mode.
Prevent the propagation of pvp flag if both players are in ffa mode.