### PR TITLE
Various database fixes

### DIFF
--- a/sql/migrations/20170724224822_world.sql
+++ b/sql/migrations/20170724224822_world.sql
@@ -1,0 +1,25 @@
+INSERT INTO `migrations` VALUES ('20170724224822');
+
+-- Fixes typos in Gilthares escort
+UPDATE `script_texts` SET
+
+`content_default` = replace('Now I feel better. Let''s get back to Ratchet. Come
+on, $n.', '\n', ' ')
+
+WHERE `entry` = -1000372;
+
+
+UPDATE `script_texts` SET
+
+`content_default` = replace('Looks like the Southsea Freebooters are heavily
+entrenched on the coast. This could get rough.', '\n', ' ')
+
+WHERE `entry` = -1000373;
+
+
+UPDATE `script_texts` SET
+
+`content_default` = replace('Captain Brightsun, $N here has freed me! $N, I am
+certain the Captain will reward your bravery.', '\n', ' ')
+
+WHERE `entry` = -1000380;

--- a/sql/migrations/20170724232859_world.sql
+++ b/sql/migrations/20170724232859_world.sql
@@ -1,0 +1,134 @@
+INSERT INTO `migrations` VALUES ('20170724232859');
+
+-- Removes references of Hemet Nesingwary Jr. from quests.
+
+
+-- Panther Mastery (Part 1)
+-- http://web.archive.org/web/20040622030850/http://wow.allakhazam.com:80/db/quest.html?wquest=190
+UPDATE `quest_template` SET
+
+`Details` = replace(replace('If you want to be a part of the hunt with this
+crack group Hemet has assembled, you''re going to need to prove yourself an able
+panther hunter. We''ll start you out easy -- don''t you worry. Let''s see you
+kill 10 young panthers to start.
+
+Tracking them down is only half the challenge...', '\n\n', '$B$B'), '\n', ' ')
+
+WHERE `entry` = 190;
+
+
+-- Raptor Mastery (Part 1)
+UPDATE `quest_template` SET
+
+`Objectives` = 'Hemet Nesingwary wants you to kill 10 Stranglethorn Raptors.',
+
+-- No source of this request text for pre-TBC. The closest source is
+-- http://web.archive.org/web/20070314190844/http://www.thottbot.com:80/q194
+-- which refers to Hemet from his son's perspective which definitely isn't
+-- correct in this case.
+
+`RequestItemsText` = replace('I never met a hunter who got any kills by standing
+around the campfire. Were you planning on killing those Stranglethorn Raptors or
+were you hoping they would die of old age?', '\n', ' ')
+
+WHERE `entry` = 194;
+
+
+-- Raptor Mastery (Part 2)
+-- http://web.archive.org/web/20050219132639/http://wow.allakhazam.com:80/db/quest.html?wquest=195
+UPDATE `quest_template` SET
+
+`Objectives` = 'Hemet Nesingwary wants you to kill 10 Lashtail Raptors.'
+
+WHERE `entry` = 195;
+
+
+-- Raptor Mastery (Part 3)
+-- http://web.archive.org/web/20050219132643/http://wow.allakhazam.com:80/db/quest.html?wquest=196
+UPDATE `quest_template` SET
+
+`Objectives` = 'Hemet Nesingwary wants you to kill 10 Jungle Stalkers.'
+
+WHERE `entry` = 196;
+
+
+-- Raptor Mastery (Part 4)
+-- http://web.archive.org/web/20050217090011/http://wow.allakhazam.com:80/db/quest.html?wquest=197
+UPDATE `quest_template` SET
+
+`Objectives` = replace('Hemet Nesingwary wants you to kill Tethis, an elusive,
+dangerous raptor in Stranglethorn.', '\n', ' ')
+
+WHERE `entry` = 197;
+
+
+-- Big Game Hunter
+-- http://web.archive.org/web/20050215231921/http://wow.allakhazam.com:80/db/quest.html?wquest=208
+UPDATE `quest_template` SET
+
+`Objectives` = replace('Hemet Nesingwary wants you to bring him the head of King
+Bangalash, the great white tiger.', '\n', ' ')
+
+WHERE `entry` = 208;
+
+
+-- Welcome to the Jungle
+-- http://web.archive.org/web/20050210142503/http://wow.allakhazam.com:80/db/quest.html?wquest=583
+UPDATE `quest_template` SET
+
+`Details` = replace(replace('Welcome to Stranglethorn!
+
+Perhaps you''re not aware of this, but that dwarf over there is the one and only
+Hemet Nesingwary, renowned war hero of the Alliance and master big game
+hunter. He''s not one for welcoming strangers into his camp, but you look like
+you''ve seen quite a bit of action in your day, %c.
+
+Being a veteran of many battles himself, Master Nesingwary has a soft spot for
+fellow heroes.
+
+Go and speak with him. Perhaps he can give you some hunting pointers.',
+'\n\n','$B$B'), '\n', ' '),
+
+`Objectives` = 'Speak with Hemet Nesingwary.'
+
+WHERE `entry` = 583;
+
+
+-- Hemet Nesingwary
+-- http://web.archive.org/web/20050119152955/http://wow.allakhazam.com:80/db/quest.html?wquest=5762
+UPDATE `quest_template` SET
+
+`Details` = replace(replace('I have a package for an old customer of mine, a
+dwarf named Hemet Nesingwary. The package took weeks to arrive, and Hemet''s
+long gone by now. He said he was going to Stranglethorn to hunt the beasts
+there, but he left me some money to send his delivery when I could.
+
+Hemet''s a rich dwarf and it''s a good idea to keep up relations with the rich
+ones, yeah? So... you want to deliver the package for me?
+
+I heard Hemet has a camp in Stranglethorn, north of Grom''gol.', '\n\n',
+'$B$B'), '\n', ' '),
+
+`Objectives` = 'Take Kravel''s Crate to Hemet Nesingwary in Stranglethorn.'
+
+WHERE `entry` = 5762;
+
+
+-- Hunting in Stranglethorn
+-- http://web.archive.org/web/20041121100030/http://wow.allakhazam.com:80/db/quest.html?wquest=5763
+UPDATE `quest_template` SET
+
+`Details` = replace(replace('Long ago, a dwarf came to this land. His name was
+Hemet and he wished to hunt great beasts. His skills with the rifle were
+uncanny, and we spent many days hunting together. Even the enmity between our
+peoples were forgotten.
+
+When he left Desolace for Stranglethorn, I vowed to one day welcome him back so
+that we may hunt again. Now is that time.
+
+Take this kodo horn to Hemet. He will know it is from me. You will find him in
+Stranglethorn, north of the Grom''gol Base camp.', '\n\n', '$B$B'), '\n', ' '),
+
+`Objectives` = 'Bring Roon''s Kodo Horn to Hemet Nesingwary in Stranglethorn.'
+
+WHERE `entry` = 5763;

--- a/sql/migrations/20170724235127_world.sql
+++ b/sql/migrations/20170724235127_world.sql
@@ -1,0 +1,4 @@
+INSERT INTO `migrations` VALUES ('20170724235127');
+
+-- Removes trailing whitespace in title
+UPDATE `quest_template` SET `Title` = 'Other Fish to Fry' WHERE `entry` = 6143;

--- a/sql/migrations/20170724235429_world.sql
+++ b/sql/migrations/20170724235429_world.sql
@@ -1,0 +1,7 @@
+INSERT INTO `migrations` VALUES ('20170724235429');
+
+-- Removes `(part 2)' suffix
+UPDATE `quest_template` SET `Title` = 'A Plague Upon Thee' WHERE `entry` = 5902;
+
+-- Removes `(part 3)' suffix
+UPDATE `quest_template` SET `Title` = 'A Plague Upon Thee' WHERE `entry` = 6390;

--- a/sql/migrations/20170724235834_world.sql
+++ b/sql/migrations/20170724235834_world.sql
@@ -1,0 +1,71 @@
+INSERT INTO `migrations` VALUES ('20170724235834');
+
+-- Rexxar is still in Desolace and his place has not yet been taken by Rokaro
+-- (TBC)
+
+-- The Testament of Rexxar
+-- The prior description was slightly wrong compared to
+-- http://web.archive.org/web/20050420112347/http://wow.allakhazam.com:80/db/quest.html?wquest=6568
+UPDATE `quest_template` SET
+
+`Details` = replace(replace('What do you know of illusions, $N? For you see, it
+is an illusion that you must create in order to circumvent the Black Flight''s
+defenses.
+
+I know of one that may be willing to assist you in your quest of deception. She
+has assisted our kind in the past when she has deemed the cause worthy.
+
+In the Western Plaguelands you will find Myranda the Hag, master illusionist -
+an exile of the Lordaeron alliance. Travel there and take with you this
+message.', '\n\n', '$B$B'), '\n', ' '),
+
+`Objectives` = replace('Deliver Rexxar''s Testament to Myranda the Hag in the
+Western Plaguelands.', '\n', ' ')
+
+WHERE `entry` = 6568;
+
+-- Ascension...
+-- http://web.archive.org/web/20050425062856/http://wow.allakhazam.com:80/db/quest.html?wquest=6601
+UPDATE `quest_template` SET
+
+`Details` = replace(replace('From the skulls of our enemies is shaped a
+medallion. You know this medallion, yesss? You have no doubt seen it worn by
+your elders.
+
+Take it, whelp. Return to the Spire and present it to General Drakkisath. The
+General will place the final enchantment upon the medallion, attuning the
+trinket to your spirit.
+
+You will wear the finished medallion as a badge of honor, symbolizing your
+ascension to one of our most guarded ranks: Guardian to the brood mother.
+
+Go!', '\n\n', '$B$B'), '\n', ' '),
+
+`Objectives` = replace('It would appear as if the charade is over. You know that
+the Amulet of Draconic Subversion that Myranda the Hag created for you will not
+function inside Blackrock Spire. Perhaps you should find Rexxar and explain your
+predicament. Show him the Dull Drakefire Amulet. Hopefully he will know what to
+do next.', '\n', ' ')
+
+WHERE `entry` = 6601;
+
+-- Blood of the Black Dragon Champion
+-- http://web.archive.org/web/20050414105313/http://wow.allakhazam.com:80/db/quest.html?wquest=6602
+UPDATE `quest_template` SET
+
+`Details` = replace(replace('You will pay the General a visit, yes, but not as
+one of the Black Dragonflight.
+
+You see, a ceremony is merely another term for blood letting to the Black
+Flight.
+
+The latent amulet merely needs the blood of the General in order to become
+active. One of their crude failsafe mechanisms.
+
+Return to Blackrock Spire and destroy Drakkisath. Bring his blood back here and
+I shall activate the key to Onyxia''s lair.', '\n\n', '$B$B'), '\n', ' '),
+
+`Objectives` = replace('Travel to Blackrock Spire and slay General
+Drakkisath. Gather his blood and return it to Rexxar.', '\n', ' ')
+
+WHERE `entry` = 6602;

--- a/sql/migrations/20170725010844_world.sql
+++ b/sql/migrations/20170725010844_world.sql
@@ -1,0 +1,6 @@
+INSERT INTO `migrations` VALUES ('20170725010844');
+
+-- http://web.archive.org/web/20071030230401/http://wow.allakhazam.com:80/db/quest.html?wquest=8388
+-- For Great Honor (8388): Category is Orgrimmar! The Battlegrounds category was
+-- added with TBC
+UPDATE `quest_template` SET `ZoneOrSort` = 1637 WHERE `entry` = 8388;

--- a/sql/migrations/20170731221326_world.sql
+++ b/sql/migrations/20170731221326_world.sql
@@ -1,0 +1,5 @@
+INSERT INTO `migrations` VALUES ('20170731221326');
+
+-- Tideress does not do frost base damage:
+-- (Joana's guide 26-27 https://youtu.be/ZjFoYPGGpsA?t=6m3s)
+UPDATE `creature_template` SET `dmgschool` = 0 WHERE `entry` = 12759;

--- a/sql/migrations/20170731222759_world.sql
+++ b/sql/migrations/20170731222759_world.sql
@@ -1,0 +1,4 @@
+INSERT INTO `migrations` VALUES ('20170731222759');
+
+-- Delete the Blackhand's Command letter upon turning in the quest
+UPDATE `quest_template` SET `ReqItemId1` = 18987, `ReqItemCount1` = 1 WHERE `entry` = 7761;

--- a/sql/migrations/20170801115934_world.sql
+++ b/sql/migrations/20170801115934_world.sql
@@ -1,0 +1,5 @@
+INSERT INTO `migrations` VALUES ('20170801115934');
+
+-- Corrects the respawn time of a specific Gromsblood in Ashenvale, old value
+-- was 7200
+UPDATE `gameobject` SET `spawntimesecs` = 2700 WHERE `guid` = 16511;

--- a/sql/migrations/20170803235323_world.sql
+++ b/sql/migrations/20170803235323_world.sql
@@ -1,0 +1,19 @@
+INSERT INTO `migrations` VALUES ('20170803235323');
+
+-- Corrects the quest details for Nothing But The Truth
+-- http://web.archive.org/web/20050214155208/http://wow.allakhazam.com:80/db/quest.html?wquest=1383
+UPDATE `quest_template` SET
+
+`Details` = replace(replace('I have just the right serum in mind. It will deal
+with the truth in precisely the way the truth should be dealt with.
+
+For this concoction I will need several Shadow Panther hearts from the Swamp. I
+also require the enchanted fungus off of the Mire Lord who resides there. I am
+sure one as able as you, $N, can persuade him to part with some.
+
+Now the hard part will be locating a Deepstrider tumor from far-off
+Desolace. Very rarely the giants there become ill and a tumor forms.
+
+Now, off you go!', '\n\n', '$B$B'), '\n', ' ')
+
+WHERE `entry` = 1383;


### PR DESCRIPTION
- Corrects some typos in the Gilthares escort at Northwatch Hold in The Barrens.
- References of Hemet Nesingwary Jr. are removed. He replaces his father in STV in 2.0.
- Removes a trailing whitespace in 'Other Fish To Fry'.
- Corrects the quest titles of the A Plague Upon Thee quest chain.
- References of Rokaro are removed and properly replaced by Rexxar.
- For Great Honor is now categorized under Orgrimmar. The Battlegrounds category was added with 2.0
- Tunes Tideress in Ashenvale to make it easier as it was in the old days. It didn't do frost base damage back then.
- Deletes the BWL attunement letter when the quest is completed.
- Corrects the respawn time of a specific Gromsblood object in Ashenvale (old value was 7200)
- Corrects the quest details for Nothing But The Truth