### PR TITLE
Add command to lock or unlock account

### DIFF
--- a/sql/migrations/20170806212645_world.sql
+++ b/sql/migrations/20170806212645_world.sql
@@ -1,0 +1,5 @@
+INSERT INTO `migrations` VALUES ('20170806212645'); 
+
+-- Strings for command ".account set locked"
+INSERT INTO `mangos_string` (`entry`, `content_default`, `content_loc1`, `content_loc2`, `content_loc3`, `content_loc4`, `content_loc5`, `content_loc6`, `content_loc7`, `content_loc8`) VALUES (1170, 'Locked field of Account %s (id %u) changed to %u.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+INSERT INTO `mangos_string` (`entry`, `content_default`, `content_loc1`, `content_loc2`, `content_loc3`, `content_loc4`, `content_loc5`, `content_loc6`, `content_loc7`, `content_loc8`) VALUES (1171, 'Incorrect parameters. Usage:\r\n.account set locked <accountname> <value>\r\nLock types: 0 None, 1 IP, 2 PIN, 4 TOTP, 8 Enforce', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);

--- a/src/game/Chat/Chat.cpp
+++ b/src/game/Chat/Chat.cpp
@@ -92,7 +92,7 @@ ChatCommand * ChatHandler::getCommandTable()
         { NODE, "addon",          SEC_ADMINISTRATOR,  true,  &ChatHandler::HandleAccountSetAddonCommand,     "", nullptr },
         { NODE, "gmlevel",        SEC_CONSOLE,        true,  &ChatHandler::HandleAccountSetGmLevelCommand,   "", nullptr },
         { NODE, "password",       SEC_CONSOLE,        true,  &ChatHandler::HandleAccountSetPasswordCommand,  "", nullptr },
-        { NODE, "locked",         SEC_GAMEMASTER,     true,  &ChatHandler::HandleAccountSetLockedCommand,      "", nullptr },
+        { NODE, "locked",         SEC_ADMINISTRATOR,  true,  &ChatHandler::HandleAccountSetLockedCommand,    "", nullptr },
         { MSTR, nullptr,       0,                  false, nullptr,                                           "", nullptr }
     };
 

--- a/src/game/Chat/Chat.cpp
+++ b/src/game/Chat/Chat.cpp
@@ -92,6 +92,7 @@ ChatCommand * ChatHandler::getCommandTable()
         { NODE, "addon",          SEC_ADMINISTRATOR,  true,  &ChatHandler::HandleAccountSetAddonCommand,     "", nullptr },
         { NODE, "gmlevel",        SEC_CONSOLE,        true,  &ChatHandler::HandleAccountSetGmLevelCommand,   "", nullptr },
         { NODE, "password",       SEC_CONSOLE,        true,  &ChatHandler::HandleAccountSetPasswordCommand,  "", nullptr },
+        { NODE, "locked",         SEC_GAMEMASTER,     true,  &ChatHandler::HandleAccountSetLockedCommand,      "", nullptr },
         { MSTR, nullptr,       0,                  false, nullptr,                                           "", nullptr }
     };
 

--- a/src/game/Chat/Chat.h
+++ b/src/game/Chat/Chat.h
@@ -342,6 +342,7 @@ class MANGOS_DLL_SPEC ChatHandler
         bool HandleAccountSetAddonCommand(char* args);
         bool HandleAccountSetGmLevelCommand(char* args);
         bool HandleAccountSetPasswordCommand(char* args);
+        bool HandleAccountSetLockedCommand(char* args);
 
         bool HandleAuctionAllianceCommand(char* args);
         bool HandleAuctionGoblinCommand(char* args);

--- a/src/game/Commands/Level3.cpp
+++ b/src/game/Commands/Level3.cpp
@@ -962,6 +962,45 @@ bool ChatHandler::HandleAccountSetPasswordCommand(char* args)
     return true;
 }
 
+/// Set locked status for account
+bool ChatHandler::HandleAccountSetLockedCommand(char* args)
+{
+    ///- Get the command line arguments
+    char* accountStr = ExtractOptNotLastArg(&args);
+
+    std::string account_name;
+    uint32 account_id = ExtractAccountId(&accountStr, &account_name);
+    if (!account_id)
+        return false;
+
+    // Let set addon state only for lesser (strong) security level
+    // or to self account
+    if (GetAccountId() && GetAccountId() != account_id &&
+        HasLowerSecurityAccount(NULL, account_id, true))
+        return false;
+
+    // allow or quoted string with possible spaces or literal without spaces
+    uint32 value;
+    if (!ExtractUInt32(&args, value))
+    {
+        PSendSysMessage(LANG_SET_LOCK_USAGE);
+        return false;
+    }
+
+    if (value < 16)
+    {
+        LoginDatabase.PExecute("UPDATE account SET locked = '%u' WHERE id = '%u'", value, account_id);
+        PSendSysMessage(LANG_SET_LOCK_SUCCESS, account_name.c_str(), account_id, value);
+    }
+    else
+    {
+        PSendSysMessage(LANG_SET_LOCK_USAGE);
+        return false;
+    }
+
+    return true;
+}
+
 bool ChatHandler::HandleMaxSkillCommand(char* /*args*/)
 {
     Player* SelectedPlayer = getSelectedPlayer();
@@ -3573,6 +3612,7 @@ bool ChatHandler::HandleFearCommand(char* /*args*/)
     }
 
     target->AddSpellAuraHolder(holder);
+    return true;
 }
 
 bool ChatHandler::HandleDamageCommand(char* args)

--- a/src/game/Commands/Level3.cpp
+++ b/src/game/Commands/Level3.cpp
@@ -973,13 +973,12 @@ bool ChatHandler::HandleAccountSetLockedCommand(char* args)
     if (!account_id)
         return false;
 
-    // Let set addon state only for lesser (strong) security level
+    // Let set locked state only for lesser (strong) security level
     // or to self account
     if (GetAccountId() && GetAccountId() != account_id &&
         HasLowerSecurityAccount(NULL, account_id, true))
         return false;
 
-    // allow or quoted string with possible spaces or literal without spaces
     uint32 value;
     if (!ExtractUInt32(&args, value))
     {

--- a/src/game/Language.h
+++ b/src/game/Language.h
@@ -968,7 +968,9 @@ enum MangosStrings
     LANG_SCRIPTS_WRONG_API              = 1167,
     LANG_SCRIPTS_RELOADED_OK            = 1168,
     LANG_SCRIPTS_OUTDATED               = 1169,
-    // Room for more level 3              1170-1199 not used
+    LANG_SET_LOCK_SUCCESS               = 1170,
+    LANG_SET_LOCK_USAGE                 = 1171,
+    // Room for more level 3              1172-1199 not used
 
     // Debug commands
     LANG_CINEMATIC_NOT_EXIST            = 1200,


### PR DESCRIPTION
This adds a command that will let you set the locked status of an account.

Usage:
`.account set locked <accountname> <value>`

Use value 0 to remove lock from account.