### PR TITLE
Update .removeriding to work on offline players.

### DIFF
--- a/sql/migrations/20170808232112_world.sql
+++ b/sql/migrations/20170808232112_world.sql
@@ -1,0 +1,7 @@
+INSERT INTO `migrations` VALUES ('20170808232112'); 
+
+-- Texts for .removeriding command.
+INSERT INTO `mangos_string` (`entry`, `content_default`, `content_loc1`, `content_loc2`, `content_loc3`, `content_loc4`, `content_loc5`, `content_loc6`, `content_loc7`, `content_loc8`) VALUES (1172, 'Invalid riding type. Try one of the following:\r\n%s', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+INSERT INTO `mangos_string` (`entry`, `content_default`, `content_loc1`, `content_loc2`, `content_loc3`, `content_loc4`, `content_loc5`, `content_loc6`, `content_loc7`, `content_loc8`) VALUES (1173, 'That player does not have %s riding skill.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+INSERT INTO `mangos_string` (`entry`, `content_default`, `content_loc1`, `content_loc2`, `content_loc3`, `content_loc4`, `content_loc5`, `content_loc6`, `content_loc7`, `content_loc8`) VALUES (1174, 'Encountered an error while attempting to remove riding skill.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+INSERT INTO `mangos_string` (`entry`, `content_default`, `content_loc1`, `content_loc2`, `content_loc3`, `content_loc4`, `content_loc5`, `content_loc6`, `content_loc7`, `content_loc8`) VALUES (1175, 'Riding skill removed from player %s.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);

--- a/src/game/Commands/Level3.cpp
+++ b/src/game/Commands/Level3.cpp
@@ -1084,17 +1084,6 @@ bool ChatHandler::HandleRemoveRidingCommand(char* args)
         { "tiger", 828 }, { "wolf", 825 }
     };
 
-    enum
-    {
-        SKILL_HORSE_RIDING  = 148,
-        SKILL_WORLF_RIDING  = 149,
-        SKILL_TIGER_RIDIING = 150,
-        SKILL_RAM_RIDING    = 152,
-        SKILL_RAPTOR_RIDING = 533,
-        SKILL_KODO_RIDING   = 713,
-        SKILL_RIDING        = 762
-    };
-
     Player* player;
     ObjectGuid target_guid;
     std::string name;

--- a/src/game/Commands/Level3.cpp
+++ b/src/game/Commands/Level3.cpp
@@ -1084,10 +1084,22 @@ bool ChatHandler::HandleRemoveRidingCommand(char* args)
         { "tiger", 828 }, { "wolf", 825 }
     };
 
+    enum
+    {
+        SKILL_HORSE_RIDING  = 148,
+        SKILL_WORLF_RIDING  = 149,
+        SKILL_TIGER_RIDIING = 150,
+        SKILL_RAM_RIDING    = 152,
+        SKILL_RAPTOR_RIDING = 533,
+        SKILL_KODO_RIDING   = 713,
+        SKILL_RIDING        = 762
+    };
+
     Player* player;
+    ObjectGuid target_guid;
     std::string name;
 
-    ExtractPlayerTarget(&args, &player, nullptr, &name);
+    ExtractPlayerTarget(&args, &player, &target_guid, &name);
 
     if (!player && name.empty())
     {
@@ -1106,7 +1118,7 @@ bool ChatHandler::HandleRemoveRidingCommand(char* args)
             options << entry.first << " ";
         }
 
-        PSendSysMessage("Unrecognised riding type. Try one of the follow: %s", options.str().c_str());
+        PSendSysMessage(LANG_REMOVE_RIDING_WRONG_TYPE, options.str().c_str());
         SetSentErrorMessage(true);
         return false;
     }
@@ -1118,29 +1130,150 @@ bool ChatHandler::HandleRemoveRidingCommand(char* args)
     }
     else
     {
-        PSendSysMessage("Sorry %s, this command doesn't quite work with offline players yet.", m_session->GetPlayerName());
-        return true;
-       /* CharacterDatabase.escape_string(name);
-
-        std::unique_ptr<QueryResult> result(CharacterDatabase.PQuery
-        (
-            "DELETE FROM character_spell WHERE spell = %u AND guid = (SELECT guid FROM characters WHERE name = '%s')",
-            it->second, name
-        ));
+        QueryResult *result = nullptr;
+        if (it->second == 33388) // When removing Apprentice Riding check for Journeyman too. It replaces the first spell.
+            result = CharacterDatabase.PQuery("SELECT spell FROM character_spell WHERE guid = %u AND spell IN (33388, 33391)", target_guid.GetCounter());
+        else
+            result = CharacterDatabase.PQuery("SELECT spell FROM character_spell WHERE guid = %u AND spell = %u", target_guid.GetCounter(), it->second);
 
         if (!result)
         {
-            PSendSysMessage(
-                "Unable to remove %s riding skill (spell: %u) from %s - does the player exist and have this skill?",
-                it->first, it->second, name
-            );
-
+            PSendSysMessage(LANG_REMOVE_RIDING_NOT_HAVE, it->first.c_str());
             SetSentErrorMessage(true);
             return false;
-        }*/
+        }
+
+        // remove the riding skill
+        switch (it->second)
+        {
+            // Horse Riding
+            case 824:
+            {
+                if (!CharacterDatabase.PExecute("DELETE FROM character_skills WHERE skill = 148 AND guid = %u", target_guid.GetCounter()))
+                {
+                    SendSysMessage(LANG_REMOVE_RIDING_ERROR);
+                    SetSentErrorMessage(true);
+                    return false;
+                }
+                break;
+            }
+            // Wolf Riding
+            case 825:
+            {
+                if (!CharacterDatabase.PExecute("DELETE FROM character_skills WHERE skill = 149 AND guid = %u", target_guid.GetCounter()))
+                {
+                    SendSysMessage(LANG_REMOVE_RIDING_ERROR);
+                    SetSentErrorMessage(true);
+                    return false;
+                }
+                break;
+            }
+            // Ram Riding
+            case 826:
+            {
+                if (!CharacterDatabase.PExecute("DELETE FROM character_skills WHERE skill = 152 AND guid = %u", target_guid.GetCounter()))
+                {
+                    SendSysMessage(LANG_REMOVE_RIDING_ERROR);
+                    SetSentErrorMessage(true);
+                    return false;
+                }
+                break;
+            }
+            // Tiger Riding
+            case 828:
+            {
+                if (!CharacterDatabase.PExecute("DELETE FROM character_skills WHERE skill = 150 AND guid = %u", target_guid.GetCounter()))
+                {
+                    SendSysMessage(LANG_REMOVE_RIDING_ERROR);
+                    SetSentErrorMessage(true);
+                    return false;
+                }
+                break;
+            }
+            // Raptor Riding
+            case 10861:
+            {
+                if (!CharacterDatabase.PExecute("DELETE FROM character_skills WHERE skill = 533 AND guid = %u", target_guid.GetCounter()))
+                {
+                    SendSysMessage(LANG_REMOVE_RIDING_ERROR);
+                    SetSentErrorMessage(true);
+                    return false;
+                }
+                break;
+            }
+            // Kodo Riding
+            case 18995:
+            {
+                if (!CharacterDatabase.PExecute("DELETE FROM character_skills WHERE skill = 713 AND guid = %u", target_guid.GetCounter()))
+                {
+                    SendSysMessage(LANG_REMOVE_RIDING_ERROR);
+                    SetSentErrorMessage(true);
+                    return false;
+                }
+                break;
+            }
+            // Apprentice Riding
+            case 33388:
+            {
+                if (!CharacterDatabase.PExecute("DELETE FROM character_skills WHERE skill = 762 AND guid = %u", target_guid.GetCounter()))
+                {
+                    SendSysMessage(LANG_REMOVE_RIDING_ERROR);
+                    SetSentErrorMessage(true);
+                    return false;
+                }
+                break;
+            }
+            // Journeyman Riding
+            case 33391:
+            {
+                if (!CharacterDatabase.PExecute("UPDATE character_skills SET value = 75, max = 75 WHERE skill = 762 AND value = 150 AND max = 150 AND guid = %u", target_guid.GetCounter()))
+                {
+                    SendSysMessage(LANG_REMOVE_RIDING_ERROR);
+                    SetSentErrorMessage(true);
+                    return false;
+                }
+                break;
+            }
+        }
+
+        // remove the riding spell
+        if (!CharacterDatabase.PExecute("DELETE FROM character_spell WHERE spell = %u AND guid = %u", it->second, target_guid.GetCounter()))
+        {
+            SendSysMessage(LANG_REMOVE_RIDING_ERROR);
+            SetSentErrorMessage(true);
+            return false;
+        }
+
+        switch (it->second)
+        {
+            // Apprentice Riding
+            case 33388:
+            {
+                // Remove Journeyman Riding too or it does nothing if he has it.
+                if (!CharacterDatabase.PExecute("DELETE FROM character_spell WHERE spell = 33391 AND guid = %u", target_guid.GetCounter()))
+                {
+                    SendSysMessage(LANG_REMOVE_RIDING_ERROR);
+                    SetSentErrorMessage(true);
+                    return false;
+                }
+                break;
+            }
+            // Journeyman Riding
+            case 33391:
+            {
+                // Add Apprentice Riding spell.
+                if (!CharacterDatabase.PExecute("INSERT INTO character_spell VALUES (%u, 33388, 1, 0)", target_guid.GetCounter()))
+                {
+                    SendSysMessage(LANG_REMOVE_RIDING_ERROR);
+                    SetSentErrorMessage(true);
+                    return false;
+                }
+                break;
+            }
+        }
     }
 
-    PSendSysMessage("Riding skill removed from %s", name.c_str()); // check
+    PSendSysMessage(LANG_REMOVE_RIDING_SUCCESS, name.c_str()); // check
     return true;
 }
 

--- a/src/game/Language.h
+++ b/src/game/Language.h
@@ -970,7 +970,11 @@ enum MangosStrings
     LANG_SCRIPTS_OUTDATED               = 1169,
     LANG_SET_LOCK_SUCCESS               = 1170,
     LANG_SET_LOCK_USAGE                 = 1171,
-    // Room for more level 3              1172-1199 not used
+    LANG_REMOVE_RIDING_WRONG_TYPE       = 1172,
+    LANG_REMOVE_RIDING_NOT_HAVE         = 1173,
+    LANG_REMOVE_RIDING_ERROR            = 1174,
+    LANG_REMOVE_RIDING_SUCCESS          = 1175,
+    // Room for more level 3              1176-1199 not used
 
     // Debug commands
     LANG_CINEMATIC_NOT_EXIST            = 1200,


### PR DESCRIPTION
You can now use the command to remove riding skill from players who are offline.

Usage:
`.removeriding <name> <skill>`