### PR TITLE
Improvements to ticket system.

### DIFF
--- a/sql/migrations/20170811162753_world.sql
+++ b/sql/migrations/20170811162753_world.sql
@@ -1,0 +1,6 @@
+INSERT INTO `migrations` VALUES ('20170811162753'); 
+
+-- Edit texts for ticket system.
+REPLACE INTO `mangos_string` (`entry`, `content_default`, `content_loc1`, `content_loc2`, `content_loc3`, `content_loc4`, `content_loc5`, `content_loc6`, `content_loc7`, `content_loc8`) VALUES (2052, '|cff00ff00New ticket from|r|cffff00ff %s.|r |cff00ff00Category:|r|cffff00ff %s.|r |cff00ff00Ticket entry:|r|cffff00ff %d.|r', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+REPLACE INTO `mangos_string` (`entry`, `content_default`, `content_loc1`, `content_loc2`, `content_loc3`, `content_loc4`, `content_loc5`, `content_loc6`, `content_loc7`, `content_loc8`) VALUES (2053, '|cff00ff00Character|r|cffff00ff %s |r|cff00ff00edited their ticket. Ticket entry:|r|cffff00ff %d.|r', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+REPLACE INTO `mangos_string` (`entry`, `content_default`, `content_loc1`, `content_loc2`, `content_loc3`, `content_loc4`, `content_loc5`, `content_loc6`, `content_loc7`, `content_loc8`) VALUES (2002, '|cff00ff00Character|r|cffff00ff %s |r|cff00ff00abandoned their ticket. Ticket entry:|r|cffff00ff %d.|r', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);

--- a/src/game/Commands/GMTicketCommands.cpp
+++ b/src/game/Commands/GMTicketCommands.cpp
@@ -277,15 +277,43 @@ bool ChatHandler::HandleGMTicketListEscalatedCommand(char* /*args*/)
     return true;
 }
 
-bool ChatHandler::HandleGMTicketListCommand(char* /*args*/)
+bool ChatHandler::HandleGMTicketListCommand(char* args)
 {
-    sTicketMgr->ShowList(*this, false);
+    static const std::unordered_map<std::string, uint8> categories
+    {
+        { "stuck", 1 },{ "behavior", 2 },{ "harassment", 2 },{ "guild", 3 },
+        { "item", 4 },{ "environment", 5 },{ "world", 5 },{ "npc", 6 },
+        { "creature", 6 },{ "creep", 6 },{ "quest", 7 },{ "questnpc", 7 },
+        { "technical", 8 },{ "account", 9 },{ "billing", 9 },{ "character", 10 }
+    };
+
+    auto it = categories.find(args);
+
+    if (it == categories.end())
+        sTicketMgr->ShowList(*this, false);
+    else
+        sTicketMgr->ShowList(*this, false, it->second);
+
     return true;
 }
 
-bool ChatHandler::HandleGMTicketListOnlineCommand(char* /*args*/)
+bool ChatHandler::HandleGMTicketListOnlineCommand(char* args)
 {
-    sTicketMgr->ShowList(*this, true);
+    static const std::unordered_map<std::string, uint8> categories
+    {
+        { "stuck", 1 },{ "behavior", 2 },{ "harassment", 2 },{ "guild", 3 },
+        { "item", 4 },{ "environment", 5 },{ "world", 5 },{ "npc", 6 },
+        { "creature", 6 },{ "creep", 6 },{ "quest", 7 },{ "questnpc", 7 },
+        { "technical", 8 },{ "account", 9 },{ "billing", 9 },{ "character", 10 }
+    };
+
+    auto it = categories.find(args);
+
+    if (it == categories.end())
+        sTicketMgr->ShowList(*this, true);
+    else
+        sTicketMgr->ShowList(*this, true, it->second);
+
     return true;
 }
 

--- a/src/game/GMTicketMgr.cpp
+++ b/src/game/GMTicketMgr.cpp
@@ -198,6 +198,35 @@ std::string GmTicket::FormatMessageString(ChatHandler& handler, const char* szCl
     return ss.str();
 }
 
+const char* GmTicket::GetTicketCategoryName(TicketType category) const
+{
+    switch (category)
+    {
+        case GMTICKET_STUCK:
+            return "Stuck";
+        case GMTICKET_BEHAVIOR_HARASSMENT:
+            return "Behavior";
+        case GMTICKET_GUILD:
+            return "Guild";
+        case GMTICKET_ITEM:
+            return "Item";
+        case GMTICKET_ENVIRONMENTAL:
+            return "Environment";
+        case GMTICKET_NONQUEST_CREEP:
+            return "Creature";
+        case GMTICKET_QUEST_QUESTNPC:
+            return "Quest";
+        case GMTICKET_TECHNICAL:
+            return "Technical";
+        case GMTICKET_ACCOUNT_BILLING:
+            return "Billing";
+        case GMTICKET_CHARACTER:
+            return "Character";
+    }
+
+    return "Unknown";
+}
+
 void GmTicket::SetUnassigned()
 {
     _assignedTo.Clear();
@@ -370,12 +399,12 @@ void TicketMgr::RemoveTicket(uint32 ticketId)
     }
 }
 
-void TicketMgr::ShowList(ChatHandler& handler, bool onlineOnly) const
+void TicketMgr::ShowList(ChatHandler& handler, bool onlineOnly, uint8 category) const
 {
     handler.SendSysMessage(onlineOnly ? LANG_COMMAND_TICKETSHOWONLINELIST : LANG_COMMAND_TICKETSHOWLIST);
     for (GmTicketList::const_iterator itr = _ticketList.begin(); itr != _ticketList.end(); ++itr)
         if (!itr->second->IsClosed() && !itr->second->IsCompleted())
-            if (!onlineOnly || itr->second->GetPlayer())
+            if ((!onlineOnly || itr->second->GetPlayer()) && (!category || (itr->second->GetTicketType() == TicketType(category))))
                 handler.SendSysMessage(itr->second->FormatMessageString(handler).c_str());
 }
 

--- a/src/game/GMTicketMgr.h
+++ b/src/game/GMTicketMgr.h
@@ -146,6 +146,7 @@ public:
     void TeleportTo(Player* player) const;
     std::string FormatMessageString(ChatHandler& handler, bool detailed = false) const;
     std::string FormatMessageString(ChatHandler& handler, const char* szClosedName, const char* szAssignedToName, const char* szUnassignedName, const char* szDeletedName, const char* szCompletedName) const;
+    const char* GetTicketCategoryName(TicketType category) const;
 
     void SetChatLog(std::list<uint32> time, std::string const& log);
     std::string const& GetChatLog() const { return _chatLog; }
@@ -260,7 +261,7 @@ public:
     void Initialize();
     void ResetTickets();
 
-    void ShowList(ChatHandler& handler, bool onlineOnly) const;
+    void ShowList(ChatHandler& handler, bool onlineOnly, uint8 category = 0) const;
     void ShowClosedList(ChatHandler& handler) const;
     void ShowEscalatedList(ChatHandler& handler) const;
 

--- a/src/game/Handlers/GMTicketHandler.cpp
+++ b/src/game/Handlers/GMTicketHandler.cpp
@@ -65,6 +65,8 @@ void WorldSession::HandleGMTicketUpdateTextOpcode(WorldPacket & recv_data)
             ticket->SetTicketType(TicketType(type));
             ticket->SaveToDB();
             response = GMTICKET_RESPONSE_UPDATE_SUCCESS;
+
+            sWorld.SendGMTicketText(LANG_COMMAND_TICKETUPDATED, GetPlayer()->GetName(), ticket->GetId());
         }
     }
 
@@ -81,7 +83,7 @@ void WorldSession::HandleGMTicketDeleteTicketOpcode(WorldPacket & /*recv_data*/)
         data << uint32(GMTICKET_RESPONSE_TICKET_DELETED);
         SendPacket(&data);
 
-        //sWorld.SendGMTicketText(LANG_COMMAND_TICKETPLAYERABANDON, GetPlayer()->GetName(), ticket->GetId());
+        sWorld.SendGMTicketText(LANG_COMMAND_TICKETPLAYERABANDON, GetPlayer()->GetName(), ticket->GetId());
 
         sTicketMgr->CloseTicket(ticket->GetId(), GetPlayer()->GetGUID());
         sTicketMgr->SendTicket(this, NULL);
@@ -139,7 +141,7 @@ void WorldSession::HandleGMTicketCreateOpcode(WorldPacket& recvData)
         sTicketMgr->AddTicket(ticket);
         sTicketMgr->UpdateLastChange();
 
-        sWorld.SendGMTicketText(LANG_COMMAND_TICKETNEW, GetPlayer()->GetName(), ticket->GetId());
+        sWorld.SendGMTicketText(LANG_COMMAND_TICKETNEW, GetPlayer()->GetName(), ticket->GetTicketCategoryName(TicketType(ticketType)), ticket->GetId());
 
         response = GMTICKET_RESPONSE_CREATE_SUCCESS;
     }


### PR DESCRIPTION
Some changes to the ticket system that were suggested.

![tickets](https://user-images.githubusercontent.com/6519171/29224481-37d391aa-7ed3-11e7-89f8-66a60bc56f11.jpg)

- Show category when a new ticket is created.
- Notify GMs when a ticket is edited or abandoned.
- Ability to list only tickets from a certain category.

The .ticket list and .ticket onlinelist commands will accept categories as an optional parameter.

The categories are: stuck, behavior/harassment, guild, item, environment/world, npc/creature/creep, quest/questnpc, technical, account/billing, character.

So if you wanted to see a list of tickets in the 'Stuck' category you would use:
`.ticket list stuck`