### PR TITLE
Fixes for Eyes of the Beast and Eagle Eye

### DIFF
--- a/src/game/AI/PetAI.cpp
+++ b/src/game/AI/PetAI.cpp
@@ -120,9 +120,9 @@ void PetAI::UpdateAI(const uint32 diff)
             DoAttack(tauntTarget, true);
     }
 
-    if (m_creature->getVictim() && m_creature->getVictim()->isAlive())
+    Unit* victim = m_creature->getVictim();
+    if (victim && victim->isAlive() && (!playerControlled || owner->GetTargetGuid() == victim->GetObjectGuid()))
     {
-
         if (_needToStop())
         {
             _stopAttack();

--- a/src/game/Handlers/MiscHandler.cpp
+++ b/src/game/Handlers/MiscHandler.cpp
@@ -1195,6 +1195,18 @@ void WorldSession::HandleFarSightOpcode(WorldPacket & recv_data)
     uint8 op;
     recv_data >> op;
 
+    if (WorldObject* obj = _player->GetMap()->GetWorldObject(_player->GetPendingFarSightGuid()))
+        if (obj->GetTypeId() == TYPEID_DYNAMICOBJECT)
+        {
+            _player->SetPendingFarSightGuid(ObjectGuid());
+            _player->GetCamera().SetView(obj);
+            // for the client to ask for a new far sight pov
+            // case Eyes of the Beast + Eagle Eye out of hunter's range
+            WorldPacket data(SMSG_CLEAR_FAR_SIGHT_IMMEDIATE);
+            _player->GetSession()->SendPacket(&data);
+            return;
+        }
+
     WorldObject* obj = _player->GetMap()->GetWorldObject(_player->GetFarSightGuid());
     if (!obj)
         return;

--- a/src/game/Handlers/MovementHandler.cpp
+++ b/src/game/Handlers/MovementHandler.cpp
@@ -438,6 +438,13 @@ void WorldSession::HandleSetActiveMoverOpcode(WorldPacket &recv_data)
             // out of range pet dismissed
             if (!pet->IsWithinDistInMap(_player, pet->GetMap()->GetGridActivationDistance()))
                 _player->RemovePet(PET_SAVE_REAGENTS);
+            else
+                if (CharmInfo* charmInfo = pet->GetCharmInfo())
+                    if (charmInfo->HasCommandState(COMMAND_STAY))
+                    {
+                        pet->StopMoving();
+                        charmInfo->SaveStayPosition();
+                    }
         }
 
     _clientMoverGuid = guid;

--- a/src/game/Handlers/PetHandler.cpp
+++ b/src/game/Handlers/PetHandler.cpp
@@ -95,6 +95,7 @@ void WorldSession::HandlePetAction(WorldPacket& recv_data)
                         pet->GetMotionMaster()->Clear(false);
                         pet->GetMotionMaster()->MoveIdle();
                         charmInfo->SetIsAtStay(true);
+                        charmInfo->SaveStayPosition();
                     }
                     charmInfo->SetCommandState(COMMAND_STAY);
 
@@ -102,7 +103,6 @@ void WorldSession::HandlePetAction(WorldPacket& recv_data)
                     charmInfo->SetIsCommandFollow(false);
                     charmInfo->SetIsFollowing(false);
                     charmInfo->SetIsReturning(false);
-                    charmInfo->SaveStayPosition();
                     break;
                 case COMMAND_FOLLOW:                        // spellid=1792  //FOLLOW
                     if (!pet->HasFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_PLAYER_CONTROLLED))

--- a/src/game/Handlers/SpellHandler.cpp
+++ b/src/game/Handlers/SpellHandler.cpp
@@ -387,6 +387,11 @@ void WorldSession::HandleCancelCastOpcode(WorldPacket& recvPacket)
     if (mover != _player && mover->GetTypeId() == TYPEID_PLAYER)
         return;
 
+    // ignore in the case of a pending possession which the player
+    // tries to cancel but it is already applied on server side
+    if (mover->GetObjectGuid() != _clientMoverGuid)
+        return;
+
     if (_player->IsNonMeleeSpellCasted(false))
         _player->InterruptNonMeleeSpells(false, spellId);
 }

--- a/src/game/Objects/Player.h
+++ b/src/game/Objects/Player.h
@@ -1944,6 +1944,14 @@ class MANGOS_DLL_SPEC Player final: public Unit
         void DoIgnoreRelocation() { if (m_bNextRelocationsIgnored) --m_bNextRelocationsIgnored; }
 
         ObjectGuid const& GetFarSightGuid() const { return GetGuidValue(PLAYER_FARSIGHT); }
+        // sometime it's needed to save the far sight object and set the view later
+        // case Eyes of the Beast + Eagle Eye
+        ObjectGuid const& GetPendingFarSightGuid() const { return m_pendingFarSightGuid;  }
+        void SetPendingFarSightGuid(ObjectGuid pendingFarSightGuid)
+        {
+            m_pendingFarSightGuid = pendingFarSightGuid;
+        }
+        ObjectGuid m_pendingFarSightGuid;
 
         uint32 GetSaveTimer() const { return m_nextSave; }
         void   SetSaveTimer(uint32 timer) { m_nextSave = timer; }

--- a/src/game/Objects/Unit.cpp
+++ b/src/game/Objects/Unit.cpp
@@ -9148,16 +9148,11 @@ bool CharmInfo::IsCommandFollow()
 
 void CharmInfo::SaveStayPosition()
 {
-    // No Unit::StopMoving while possessed
-    if (m_unit->HasFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_PLAYER_CONTROLLED))
-        m_unit->GetPosition(_stayX, _stayY, _stayZ);
-    else //! At this point a new spline destination is enabled because of Unit::StopMoving()
-    {
-        G3D::Vector3 stayPos = m_unit->movespline->FinalDestination();
-        _stayX = stayPos.x;
-        _stayY = stayPos.y;
-        _stayZ = stayPos.z;
-    }
+    //! At this point a new spline destination is enabled because of Unit::StopMoving()
+    G3D::Vector3 stayPos = m_unit->movespline->FinalDestination();
+    _stayX = stayPos.x;
+    _stayY = stayPos.y;
+    _stayZ = stayPos.z;
 }
 
 void CharmInfo::GetStayPosition(float &x, float &y, float &z)

--- a/src/game/Spells/SpellEffects.cpp
+++ b/src/game/Spells/SpellEffects.cpp
@@ -3040,7 +3040,19 @@ void Spell::EffectAddFarsight(SpellEffectIndex eff_idx)
     m_caster->AddDynObject(dynObj);
     m_caster->GetMap()->Add(dynObj);
 
-    ((Player*)m_caster)->GetCamera().SetView(dynObj);
+    Player* pCaster = m_caster->ToPlayer();
+
+    // the object could be created out of the hunter's update range
+    if (!dynObj->IsWithinDistInMap(pCaster, dynObj->GetMap()->GetGridActivationDistance()))
+        dynObj->SendCreateUpdateToPlayer(pCaster);
+
+
+    // case Eyes of the Beast + Eagle Eye, save the object
+    // so it'll be used in WorldSession::HandleFarSightOpcode
+    if (pCaster->GetSession()->IsPendingMoverSwap())
+        pCaster->SetPendingFarSightGuid(dynObj->GetObjectGuid());
+    else
+        pCaster->GetCamera().SetView(dynObj);
 }
 
 void Spell::EffectSummonWild(SpellEffectIndex eff_idx)

--- a/src/game/WorldSession.cpp
+++ b/src/game/WorldSession.cpp
@@ -1379,3 +1379,8 @@ bool WorldSession::CharacterScreenIdleKick(uint32 currTime)
 
     return false;
 }
+
+bool  WorldSession::IsPendingMoverSwap() const
+{
+    return _clientMoverGuid != _player->GetMover()->GetObjectGuid();
+}

--- a/src/game/WorldSession.h
+++ b/src/game/WorldSession.h
@@ -530,6 +530,9 @@ class MANGOS_DLL_SPEC WorldSession
 
         uint32 m_idleTime;
 
+        // for possession spells, pending CMSG_SET_ACTIVE_MOVER
+        bool IsPendingMoverSwap() const;
+
     public:                                                 // opcodes handlers
 
         void Handle_NULL(WorldPacket& recvPacket);          // not used


### PR DESCRIPTION
Fix #1563 :
- prevent the possessed pet from attacking a non selected target
- it surfaced that there are 2 possible ways the stay mode after EOTB could work with no evidence that helps in picking one. Here I implement the most simple and intuitive way (Jabark's) : after EOTB end the pet stays put.

Fix also issues reported by Kampeador on discord :
- cancelling  EOTB at the last moment stuck the pet until a new EOTB cast.
- cast Eagle Eye while using EOTB would fail and sometime teleport the player on pet's location (probably causing player disconnection on live servers). Keep in mind if you test that it can still fail in the case of a near 0 network latency (client on the server's machine) because CMSG_SET_ACTIVE_MOVER could arrive before Spell::EffectAddFarsight. In a real situation it should work.

Also Eagle Eye could fail even if cast from the hunter POV because the far sight object can be created outside of update range, might depend of server settings though.

Fix #1946 (duplicate).