### PR TITLE
Implement new progression system.

### DIFF
--- a/sql/migrations/20170816025732_world.sql
+++ b/sql/migrations/20170816025732_world.sql
@@ -1,0 +1,57 @@
+INSERT INTO `migrations` VALUES ('20170816025732'); 
+
+-- Implement new progression system.
+ALTER TABLE `areatrigger_teleport`
+	ADD COLUMN `patch` TINYINT(3) UNSIGNED NOT NULL DEFAULT '0' AFTER `id`,
+	DROP PRIMARY KEY,
+	ADD PRIMARY KEY (`id`, `patch`);
+	
+ALTER TABLE `game_event`
+	ADD COLUMN `patch_min` TINYINT(3) UNSIGNED NOT NULL DEFAULT '0' AFTER `disabled`,
+	ADD COLUMN `patch_max` TINYINT(3) UNSIGNED NOT NULL DEFAULT '10' AFTER `patch_min`;
+	
+ALTER TABLE `creature`
+	ADD COLUMN `patch_min` TINYINT(3) UNSIGNED NOT NULL DEFAULT '0' AFTER `spawnFlags`,
+	ADD COLUMN `patch_max` TINYINT(3) UNSIGNED NOT NULL DEFAULT '10' AFTER `patch_min`;
+
+ALTER TABLE `creature_template`
+	ADD COLUMN `patch` TINYINT(3) UNSIGNED NOT NULL DEFAULT '0' AFTER `entry`,
+	DROP PRIMARY KEY,
+	ADD PRIMARY KEY (`entry`, `patch`);
+	
+ALTER TABLE `creature_addon`
+	ADD COLUMN `patch` TINYINT(3) UNSIGNED NOT NULL DEFAULT '0' AFTER `guid`,
+	DROP PRIMARY KEY,
+	ADD PRIMARY KEY (`guid`, `patch`);
+	
+ALTER TABLE `creature_template_addon`
+	ADD COLUMN `patch` TINYINT(3) UNSIGNED NOT NULL DEFAULT '0' AFTER `entry`,
+	DROP PRIMARY KEY,
+	ADD PRIMARY KEY (`entry`, `patch`);
+	
+ALTER TABLE `creature_equip_template`
+	ADD COLUMN `patch` TINYINT(3) UNSIGNED NOT NULL DEFAULT '0' AFTER `entry`,
+	DROP PRIMARY KEY,
+	ADD PRIMARY KEY (`entry`, `patch`);
+
+ALTER TABLE `creature_equip_template_raw`
+	ADD COLUMN `patch` TINYINT(3) UNSIGNED NOT NULL DEFAULT '0' AFTER `entry`,
+	DROP PRIMARY KEY,
+	ADD PRIMARY KEY (`entry`, `patch`);
+	
+ALTER TABLE `item_template`
+	ADD COLUMN `patch` TINYINT(3) UNSIGNED NOT NULL DEFAULT '0' AFTER `entry`,
+	DROP PRIMARY KEY,
+	ADD PRIMARY KEY (`entry`, `patch`);
+	
+ALTER TABLE `quest_template`
+	ADD COLUMN `patch` TINYINT(3) UNSIGNED NOT NULL DEFAULT '0' AFTER `entry`,
+	DROP PRIMARY KEY,
+	ADD PRIMARY KEY (`entry`, `patch`);
+	
+CREATE TABLE IF NOT EXISTS `forbidden_items` (
+  `entry` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `patch` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `AfterOrBefore` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  PRIMARY KEY (`entry`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;

--- a/sql/migrations/20170816025732_world.sql
+++ b/sql/migrations/20170816025732_world.sql
@@ -55,3 +55,54 @@ CREATE TABLE IF NOT EXISTS `forbidden_items` (
   `AfterOrBefore` tinyint(3) unsigned NOT NULL DEFAULT '0',
   PRIMARY KEY (`entry`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+
+-- Dumping structure for table mangos.battleground_template
+DROP TABLE IF EXISTS `battleground_template`;
+CREATE TABLE IF NOT EXISTS `battleground_template` (
+  `id` mediumint(8) unsigned NOT NULL,
+  `patch` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `MinPlayersPerTeam` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `MaxPlayersPerTeam` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `MinLvl` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `MaxLvl` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `AllianceStartLoc` mediumint(8) unsigned NOT NULL,
+  `AllianceStartO` float NOT NULL,
+  `HordeStartLoc` mediumint(8) unsigned NOT NULL,
+  `HordeStartO` float NOT NULL,
+  PRIMARY KEY (`id`,`patch`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+
+-- All battlegrounds disabled until 1.5.
+INSERT INTO `battleground_template` (`id`, `patch`, `MinPlayersPerTeam`, `MaxPlayersPerTeam`, `MinLvl`, `MaxLvl`, `AllianceStartLoc`, `AllianceStartO`, `HordeStartLoc`, `HordeStartO`) VALUES
+	(1, 0, 20, 40, 61, 61, 611, 2.72532, 610, 2.27452);
+INSERT INTO `battleground_template` (`id`, `patch`, `MinPlayersPerTeam`, `MaxPlayersPerTeam`, `MinLvl`, `MaxLvl`, `AllianceStartLoc`, `AllianceStartO`, `HordeStartLoc`, `HordeStartO`) VALUES
+	(2, 0, 4, 10, 61, 61, 769, 3.14159, 770, 3.14159);
+INSERT INTO `battleground_template` (`id`, `patch`, `MinPlayersPerTeam`, `MaxPlayersPerTeam`, `MinLvl`, `MaxLvl`, `AllianceStartLoc`, `AllianceStartO`, `HordeStartLoc`, `HordeStartO`) VALUES
+	(3, 0, 6, 15, 61, 61, 890, 3.40156, 889, 0.263892);
+
+-- World of Warcraft Client Patch 1.5.0 (2005-06-07)
+-- "Battlegrounds arrive!
+-- The Warsong Gulch and Alterac Valley battlegrounds are now available."
+INSERT INTO `battleground_template` (`id`, `patch`, `MinPlayersPerTeam`, `MaxPlayersPerTeam`, `MinLvl`, `MaxLvl`, `AllianceStartLoc`, `AllianceStartO`, `HordeStartLoc`, `HordeStartO`) VALUES
+	(2, 3, 4, 10, 21, 60, 769, 3.14159, 770, 3.14159);
+INSERT INTO `battleground_template` (`id`, `patch`, `MinPlayersPerTeam`, `MaxPlayersPerTeam`, `MinLvl`, `MaxLvl`, `AllianceStartLoc`, `AllianceStartO`, `HordeStartLoc`, `HordeStartO`) VALUES
+	(1, 3, 30, 40, 51, 60, 611, 2.72532, 610, 2.27452);
+
+-- World of Warcraft Client Patch 1.7.0 (2005-09-13)
+-- Arathi Basin added to the game.
+INSERT INTO `battleground_template` (`id`, `patch`, `MinPlayersPerTeam`, `MaxPlayersPerTeam`, `MinLvl`, `MaxLvl`, `AllianceStartLoc`, `AllianceStartO`, `HordeStartLoc`, `HordeStartO`) VALUES
+	(3, 5, 6, 15, 20, 60, 890, 3.40156, 889, 0.263892);
+-- "Warsong Gulch and Arathi Basin will now be level-banded as follows: 20-29, 30-39, 40-49, 50-59, 60."
+-- http://pc.gamespy.com/pc/world-of-warcraft/625886p4.html <- Mentions that 50s play against 60s in WSG.
+INSERT INTO `battleground_template` (`id`, `patch`, `MinPlayersPerTeam`, `MaxPlayersPerTeam`, `MinLvl`, `MaxLvl`, `AllianceStartLoc`, `AllianceStartO`, `HordeStartLoc`, `HordeStartO`) VALUES
+	(2, 5, 4, 10, 20, 60, 769, 3.14159, 770, 3.14159);
+	
+-- World of Warcraft Client Patch 1.8.0 (2005-10-11)
+-- "Players of levels 10 - 19 will now be able to participate in the battle for Warsong Gulch."
+-- Minimum level for WSG was 20 previously, 21 before 1.7.0.
+INSERT INTO `battleground_template` (`id`, `patch`, `MinPlayersPerTeam`, `MaxPlayersPerTeam`, `MinLvl`, `MaxLvl`, `AllianceStartLoc`, `AllianceStartO`, `HordeStartLoc`, `HordeStartO`) VALUES
+	(2, 6, 4, 10, 10, 60, 769, 3.14159, 770, 3.14159);
+-- "The minimum number of players required to start a battle in Alterac Valley has been lowered to 20 (the maximum is still 40)."
+INSERT INTO `battleground_template` (`id`, `patch`, `MinPlayersPerTeam`, `MaxPlayersPerTeam`, `MinLvl`, `MaxLvl`, `AllianceStartLoc`, `AllianceStartO`, `HordeStartLoc`, `HordeStartO`) VALUES
+	(1, 6, 20, 40, 51, 60, 611, 2.72532, 610, 2.27452);
+

--- a/src/game/Battlegrounds/BattleGroundMgr.cpp
+++ b/src/game/Battlegrounds/BattleGroundMgr.cpp
@@ -1225,7 +1225,7 @@ void BattleGroundMgr::CreateInitialBattleGrounds()
     uint32 count = 0;
 
     //                                                0   1                 2                 3      4      5                6              7             8
-    QueryResult *result = WorldDatabase.Query("SELECT id, MinPlayersPerTeam,MaxPlayersPerTeam,MinLvl,MaxLvl,AllianceStartLoc,AllianceStartO,HordeStartLoc,HordeStartO FROM battleground_template");
+    QueryResult *result = WorldDatabase.PQuery("SELECT id, MinPlayersPerTeam,MaxPlayersPerTeam,MinLvl,MaxLvl,AllianceStartLoc,AllianceStartO,HordeStartLoc,HordeStartO FROM battleground_template t1 WHERE patch=(SELECT max(patch) FROM battleground_template t2 WHERE t1.id=t2.id && patch <= %u)", sWorld.GetWowPatch());
 
     if (!result)
     {

--- a/src/game/GameEventMgr.cpp
+++ b/src/game/GameEventMgr.cpp
@@ -185,7 +185,7 @@ void GameEventMgr::LoadFromDB()
         mGameEvent.resize(max_event_id + 1);
     }
 
-    QueryResult *result = WorldDatabase.Query("SELECT entry,UNIX_TIMESTAMP(start_time),UNIX_TIMESTAMP(end_time),occurence,length,holiday,description,hardcoded,disabled FROM game_event");
+    QueryResult *result = WorldDatabase.Query("SELECT entry,UNIX_TIMESTAMP(start_time),UNIX_TIMESTAMP(end_time),occurence,length,holiday,description,hardcoded,disabled,patch_min,patch_max FROM game_event");
     if (!result)
     {
         mGameEvent.clear();
@@ -208,7 +208,7 @@ void GameEventMgr::LoadFromDB()
             uint16 event_id = fields[0].GetUInt16();
             if (event_id == 0)
             {
-                sLog.outErrorDb("`game_event` game event id (%i) is reserved and can't be used.", event_id);
+                sLog.outErrorDb("Table `game_event` game event id (%i) is reserved and can't be used.", event_id);
                 continue;
             }
 
@@ -223,13 +223,26 @@ void GameEventMgr::LoadFromDB()
 
             if (pGameEvent.length == 0)                         // length>0 is validity check
             {
-                sLog.outErrorDb("`game_event` game event id (%i) have length 0 and can't be used.", event_id);
+                sLog.outErrorDb("Table `game_event` game event id (%i) have length 0 and can't be used.", event_id);
                 continue;
             }
 
             pGameEvent.description  = fields[6].GetCppString();
             pGameEvent.hardcoded    = fields[7].GetUInt8();
             pGameEvent.disabled     = fields[8].GetUInt8();
+            uint8 patch_min         = fields[9].GetUInt8();
+            uint8 patch_max         = fields[10].GetUInt8();
+
+            if ((patch_min > patch_max) || (patch_max > 10))
+            {
+                sLog.outErrorDb("Table `game_event` game event id (%i) has invalid values min_patch=%u, max_patch=%u.", event_id, patch_min, patch_max);
+                sLog.out(LOG_DBERRFIX, "UPDATE game_event SET min_patch=0, max_patch=10 WHERE entry=%u;", event_id);
+                patch_min = 0;
+                patch_max = 10;
+            }
+
+            if (!((sWorld.GetWowPatch() >= patch_min) && (sWorld.GetWowPatch() <= patch_max)))
+                pGameEvent.disabled = 1;
         }
         while (result->NextRow());
         delete result;

--- a/src/game/LootMgr.cpp
+++ b/src/game/LootMgr.cpp
@@ -99,7 +99,7 @@ void LootStore::LoadLootTable()
     sLog.outString("%s :", GetName());
 
     //                                                 0      1     2                    3        4              5         6
-    QueryResult* result = WorldDatabase.PQuery("SELECT entry, item, ChanceOrQuestChance, groupid, mincountOrRef, maxcount, condition_id FROM %s", GetName());
+    QueryResult* result = WorldDatabase.PQuery("SELECT entry, item, ChanceOrQuestChance, groupid, mincountOrRef, maxcount, condition_id FROM %s WHERE (mincountOrRef < 0) || (item NOT IN (SELECT entry FROM forbidden_items WHERE (AfterOrBefore = 0 && patch <= %u) || (AfterOrBefore = 1 && patch >= %u)))", GetName(), sWorld.GetWowPatch(), sWorld.GetWowPatch());
 
     if (result)
     {

--- a/src/game/ObjectMgr.cpp
+++ b/src/game/ObjectMgr.cpp
@@ -895,7 +895,7 @@ struct SQLCreatureLoader : public SQLStorageLoaderBase<SQLCreatureLoader, SQLSto
 void ObjectMgr::LoadCreatureTemplates()
 {
     SQLCreatureLoader loader;
-    loader.Load(sCreatureStorage);
+    loader.LoadProgressive(sCreatureStorage, sWorld.GetWowPatch());
 
     sLog.outString(">> Loaded %u creature definitions", sCreatureStorage.GetRecordCount());
     sLog.outString();
@@ -1121,7 +1121,7 @@ void ObjectMgr::ConvertCreatureAddonAuras(CreatureDataAddon* addon, char const* 
 
 void ObjectMgr::LoadCreatureAddons(SQLStorage& creatureaddons, char const* entryName, char const* comment)
 {
-    creatureaddons.Load();
+    creatureaddons.LoadProgressive(sWorld.GetWowPatch());
 
     sLog.outString(">> Loaded %u %s", creatureaddons.GetRecordCount(), comment);
     sLog.outString();
@@ -1186,7 +1186,7 @@ EquipmentInfoRaw const* ObjectMgr::GetEquipmentInfoRaw(uint32 entry)
 
 void ObjectMgr::LoadEquipmentTemplates()
 {
-    sEquipmentStorage.Load(true);
+    sEquipmentStorage.LoadProgressive(sWorld.GetWowPatch(), true);
 
     for (uint32 i = 0; i < sEquipmentStorage.GetMaxEntry(); ++i)
     {
@@ -1228,7 +1228,7 @@ void ObjectMgr::LoadEquipmentTemplates()
     sLog.outString(">> Loaded %u equipment template", sEquipmentStorage.GetRecordCount());
     sLog.outString();
 
-    sEquipmentStorageRaw.Load(false);
+    sEquipmentStorageRaw.LoadProgressive(sWorld.GetWowPatch(), false);
     for (uint32 i = 1; i < sEquipmentStorageRaw.GetMaxEntry(); ++i)
         if (sEquipmentStorageRaw.LookupEntry<EquipmentInfoRaw>(i))
             if (sEquipmentStorage.LookupEntry<EquipmentInfo>(i))
@@ -1394,8 +1394,8 @@ void ObjectMgr::LoadCreatures(bool reload)
                           "equipment_id, position_x, position_y, position_z, orientation, spawntimesecs, spawndist, currentwaypoint,"
                           //   12         13       14          15            16
                           "curhealth, curmana, DeathState, MovementType, event,"
-                          //   17                        18                                 19
-                          "pool_creature.pool_entry, pool_creature_template.pool_entry, spawnFlags "
+                          //   17                        18                                 19          20        21
+                          "pool_creature.pool_entry, pool_creature_template.pool_entry, spawnFlags, patch_min, patch_max "
                           "FROM creature "
                           "LEFT OUTER JOIN game_event_creature ON creature.guid = game_event_creature.guid "
                           "LEFT OUTER JOIN pool_creature ON creature.guid = pool_creature.guid "
@@ -1423,12 +1423,29 @@ void ObjectMgr::LoadCreatures(bool reload)
 
         uint32 guid         = fields[ 0].GetUInt32();
         uint32 entry        = fields[ 1].GetUInt32();
+        uint8 patch_min     = fields[20].GetUInt8();
+        uint8 patch_max     = fields[21].GetUInt8();
+        bool existsInPatch  = true;
+
+        if ((patch_min > patch_max) || (patch_max > 10))
+        {
+            sLog.outErrorDb("Table `creature` GUID %u (entry %u) has invalid values min_patch=%u, max_patch=%u.", guid, entry, patch_min, patch_max);
+            sLog.out(LOG_DBERRFIX, "UPDATE creature SET min_patch=0, max_patch=10 WHERE guid=%u AND id=%u;", guid, entry);
+            patch_min = 0;
+            patch_max = 10;
+        }
+
+        if (!((sWorld.GetWowPatch() >= patch_min) && (sWorld.GetWowPatch() <= patch_max)))
+            existsInPatch = false;
 
         CreatureInfo const* cInfo = GetCreatureTemplate(entry);
         if (!cInfo)
         {
-            sLog.outErrorDb("Table `creature` has creature (GUID: %u) with non existing creature entry %u, skipped.", guid, entry);
-            sLog.out(LOG_DBERRFIX, "DELETE FROM creature WHERE guid=%u;", guid);
+            if (existsInPatch) // don't print error when it is not loaded for the current patch
+            {
+                sLog.outErrorDb("Table `creature` has creature (GUID: %u) with non existing creature entry %u, skipped.", guid, entry);
+                sLog.out(LOG_DBERRFIX, "DELETE FROM creature WHERE guid=%u;", guid);
+            }
             continue;
         }
 
@@ -1463,6 +1480,9 @@ void ObjectMgr::LoadCreatures(bool reload)
             sLog.out(LOG_DBERRFIX, "DELETE FROM creature WHERE guid=%u AND id=%u;", guid, data.id);
             continue;
         }
+
+        if (!existsInPatch)
+            data.spawnFlags |= SPAWN_FLAG_DISABLED;
 
         if (data.modelid_override > 0 && !sCreatureDisplayInfoStore.LookupEntry(data.modelid_override))
         {
@@ -1533,7 +1553,7 @@ void ObjectMgr::LoadCreatures(bool reload)
             }
         }
 
-        if (!alreadyPresent && gameEvent == 0 && GuidPoolId == 0 && EntryPoolId == 0) // if not this is to be managed by GameEvent System or Pool system
+        if (!alreadyPresent && existsInPatch && gameEvent == 0 && GuidPoolId == 0 && EntryPoolId == 0) // if not this is to be managed by GameEvent System or Pool system
             AddCreatureToGrid(guid, &data);
         ++count;
 
@@ -1903,7 +1923,7 @@ struct SQLItemLoader : public SQLStorageLoaderBase<SQLItemLoader, SQLStorage>
 void ObjectMgr::LoadItemPrototypes()
 {
     SQLItemLoader loader;
-    loader.Load(sItemStorage);
+    loader.LoadProgressive(sItemStorage, sWorld.GetWowPatch());
     mQuestStartingItems.clear();
     sLog.outString(">> Loaded %u item prototypes", sItemStorage.GetRecordCount());
     sLog.outString();
@@ -3259,7 +3279,7 @@ void ObjectMgr::LoadQuests()
     m_ExclusiveQuestGroups.clear();
 
     //                                                0      1       2           3         4           5     6                7              8              9
-    QueryResult *result = WorldDatabase.Query("SELECT entry, Method, ZoneOrSort, MinLevel, QuestLevel, Type, RequiredClasses, RequiredRaces, RequiredSkill, RequiredSkillValue,"
+    QueryResult *result = WorldDatabase.PQuery("SELECT entry, Method, ZoneOrSort, MinLevel, QuestLevel, Type, RequiredClasses, RequiredRaces, RequiredSkill, RequiredSkillValue,"
                           //   10                   11                 12                     13                   14                     15                   16                17
                           "RepObjectiveFaction, RepObjectiveValue, RequiredMinRepFaction, RequiredMinRepValue, RequiredMaxRepFaction, RequiredMaxRepValue, SuggestedPlayers, LimitTime,"
                           //   18          19            20           21           22              23                24         25            26
@@ -3292,7 +3312,7 @@ void ObjectMgr::LoadQuests()
                           "OfferRewardEmoteDelay1, OfferRewardEmoteDelay2, OfferRewardEmoteDelay3, OfferRewardEmoteDelay4,"
                           //   123          124
                           "StartScript, CompleteScript"
-                          " FROM quest_template");
+                          " FROM quest_template t1 WHERE patch=(SELECT max(patch) FROM quest_template t2 WHERE t1.entry=t2.entry && patch <= %u)", sWorld.GetWowPatch());
     if (!result)
     {
         BarGoLink bar(1);
@@ -5219,7 +5239,7 @@ void ObjectMgr::LoadAreaTriggerTeleports()
     uint32 count = 0;
 
     //                                                0   1               2              3               4                    5                      6                    7                     8           9                  10
-    QueryResult *result = WorldDatabase.Query("SELECT id, required_level, required_item, required_item2, required_quest_done, required_failed_text, target_map, target_position_x, target_position_y, target_position_z, target_orientation FROM areatrigger_teleport");
+    QueryResult *result = WorldDatabase.PQuery("SELECT id, required_level, required_item, required_item2, required_quest_done, required_failed_text, target_map, target_position_x, target_position_y, target_position_z, target_orientation FROM areatrigger_teleport t1 WHERE patch=(SELECT max(patch) FROM areatrigger_teleport t2 WHERE t1.id=t2.id && patch <= %u)", sWorld.GetWowPatch());
     if (!result)
     {
 
@@ -7601,7 +7621,7 @@ void ObjectMgr::LoadVendors(char const* tableName, bool isTemplates)
 
     std::set<uint32> skip_vendors;
 
-    QueryResult *result = WorldDatabase.PQuery("SELECT entry, item, maxcount, incrtime FROM %s", tableName);
+    QueryResult *result = WorldDatabase.PQuery("SELECT entry, item, maxcount, incrtime FROM %s WHERE (item NOT IN (SELECT entry FROM forbidden_items WHERE (AfterOrBefore = 0 && patch <= %u) || (AfterOrBefore = 1 && patch >= %u)))", tableName, sWorld.GetWowPatch(), sWorld.GetWowPatch());
     if (!result)
     {
         BarGoLink bar(1);
@@ -9020,6 +9040,19 @@ bool PlayerCondition::Meets(Player const* player, Map const* map, WorldObject co
                 case 3:                                     // Creature source is dead
                     return !source || source->GetTypeId() != TYPEID_UNIT || !((Unit*)source)->isAlive();
             }
+        case CONDITION_WOW_PATCH:
+        {
+            switch (m_value2)
+            {
+                case 0:
+                    return sWorld.GetWowPatch() == m_value1;
+                case 1:
+                    return sWorld.GetWowPatch() >= m_value1;
+                case 2:
+                    return sWorld.GetWowPatch() <= m_value1;
+            }
+            return false;
+        }
         default:
             return false;
     }
@@ -9425,6 +9458,20 @@ bool PlayerCondition::IsValid(uint16 entry, ConditionType condition, uint32 valu
             }
             break;
         }
+        case CONDITION_WOW_PATCH:
+        {
+            if (value1 > 10)
+            {
+                sLog.outErrorDb("Patch condition (entry %u, type %u) has an invalid value in value1 (must be 0..10), skipping.", entry, condition, value1);
+                return false;
+            }
+            if (value2 > 2)
+            {
+                sLog.outErrorDb("Patch condition (entry %u, type %u) has invalid argument %u (must be 0..2), skipped.", entry, condition, value2);
+                return false;
+            }
+            break;
+        }
         case CONDITION_NONE:
             break;
         default:
@@ -9458,6 +9505,7 @@ bool PlayerCondition::CanBeUsedWithoutPlayer(uint16 entry)
         case CONDITION_INSTANCE_SCRIPT:
         case CONDITION_SOURCE_AURA:
         case CONDITION_LAST_WAYPOINT:
+        case CONDITION_WOW_PATCH:
             return true;
         default:
             return false;

--- a/src/game/ObjectMgr.h
+++ b/src/game/ObjectMgr.h
@@ -343,6 +343,8 @@ enum ConditionType
     CONDITION_GENDER                = 35,                   // 0=male, 1=female, 2=none (see enum Gender)
     CONDITION_DEAD_OR_AWAY          = 36,                   // value1: 0=player dead, 1=player is dead (with group dead), 2=player in instance are dead, 3=creature is dead
                                                             // value2: if != 0 only consider players in range of this value
+    CONDITION_WOW_PATCH             = 37,                   // value1: wow patch setting from config (0-10)
+                                                            // value2: 0, 1 or 2 (0: equal to, 1: equal or higher than, 2: equal or less than)
 };
 
 enum ConditionSource                                        // From where was the condition called?

--- a/src/shared/Database/SQLStorage.cpp
+++ b/src/shared/Database/SQLStorage.cpp
@@ -140,6 +140,12 @@ void SQLStorage::Load(bool error_at_empty /*= true*/)
     loader.Load(*this, error_at_empty);
 }
 
+void SQLStorage::LoadProgressive(uint8 wow_patch, bool error_at_empty /*= true*/)
+{
+    SQLStorageLoader loader;
+    loader.LoadProgressive(*this, wow_patch, error_at_empty);
+}
+
 SQLStorage::SQLStorage(const char* fmt, const char* _entry_field, const char* sqlname)
 {
     Initialize(sqlname, _entry_field, fmt, fmt);

--- a/src/shared/Database/SQLStorage.h
+++ b/src/shared/Database/SQLStorage.h
@@ -120,6 +120,7 @@ class SQLStorage : public SQLStorageBase
         }
 
         void Load(bool error_at_empty = true);
+        void LoadProgressive(uint8 wow_patch, bool error_at_empty = true);
 
         void EraseEntry(uint32 id);
 
@@ -251,6 +252,7 @@ class SQLStorageLoaderBase
 {
     public:
         void Load(StorageClass& storage, bool error_at_empty = true);
+        void LoadProgressive(StorageClass& storage, uint8 wow_patch, bool error_at_empty = true);
 
         template<class S, class D>
         void convert(uint32 field_pos, S src, D& dst);


### PR DESCRIPTION
This implements a new progression system, making the separate sql files for every patch obsolete. We can now populate data for all patches in the same database, by just marking every entry with the patch in which it was added in the game.

It uses the WowPatch setting in the mangosd.conf file.
**Patch values go from 0 for 1.2, to 10 for 1.12.**

The following tables now have a `patch` column:
- `areatrigger_teleport`
- `battleground_template`
- `creature_addon`
- `creature_equip_template`
- `creature_equip_template_raw`
- `creature_template`
- `creature_template_addon`
- `item_template`
- `quest_template`

The `patch` column is a key and it indicates the patch in which this entry was added to the game. You can have multiple copies of every entry, but for different patches. The server will only load the entry for the latest patch that is not bigger than the current patch value set in the mangosd config file.

Example time:

If an item was added in patch 1.4, and had it's stats changed later in 1.10, you would need two entries in `item_template` for this item. 

One entry will have `patch` set to 2, this is the original version.
The other entry will have `patch` set to 8, this entry is for the updated version.

If the server patch value in the config is set to 0 or 1, this particular item will not be loaded at all and it will not exist. If the value is between 2 and 7, it will load the original version of the item that was added in patch 1.4. Once the config patch value is set to 8 or above, it will load the second entry, the updated version of the item.

**You only need to add additional entries for the patches where the item changed, not for every patch.** The server will know which one to load based on the WowPatch setting in the config file. I used the `item_template` table as an example, but this logic applies to all the tables i listed above.

The following tables now have a `patch_min` and `patch_max` columns:
- `creature`
- `game_event`

The `patch_min` column indicates the minimum patch that needs to be reached for this entry to work. The `patch_max` value indicated the maximum patch, after which it will not work. If the current patch value from the config file is outside of this range, the entry will not be active. They still get loaded to prevent startup errors, but they are set to disabled, so the creatures will not spawn, and the game events will not start.

**These  columns are not keys, so you can't have duplicated entries in these tables.** I've implemented these columns differently, because they are used differently than the template tables. For example, take the Purgation Isle issue. Up until 1.10 there are supposed to be different mobs spawned on the island, so we need to be able to specify a maximum patch after which the old mobs will not be spawned. And it does not make sense to have different creatures added with the same guid, as that would be confusing and could cause many mistakes. In the case of the `game_event` table, there are events that are only for specific patches, for example the AQ Gate Opening event, so we need a min and max patch values here too.

There is also a new table:
- `forbidden_items`

Structure:
```
`entry` mediumint(8) unsigned NOT NULL DEFAULT '0',
`patch` tinyint(3) unsigned NOT NULL DEFAULT '0',
`AfterOrBefore` tinyint(3) unsigned NOT NULL DEFAULT '0',
```

Items added to this table will not be sold by vendors or drop as loot.  The `AfterOrBefore` column indicates whether the item is forbidden after or before the patch specified. So if you want the item 17782 not to drop after we reach patch 1.5 you will add the following values:
`INSERT INTO forbidden_items VALUES (17782, 3, 0);`

Additionally, there is now a new condition type.
- CONDITION_WOW_PATCH (37)

The first value of the condition is the patch number, the second is 0 for equals, 1 for equals or above, 2 for equals or below. Conditions can be used for loot, gossip options, scripts and others.

Now it is up to people who work on progression/itemization to populate the correct patch values into the database. I will give a few more examples below to make things clearer.
