### PR TITLE
Fix For The Fix To Fix Sunder Armor Procs

### DIFF
--- a/src/game/Spells/Spell.cpp
+++ b/src/game/Spells/Spell.cpp
@@ -1285,10 +1285,6 @@ void Spell::DoAllEffectOnTarget(TargetInfo *target)
                             break;
                     }
 
-        // Sunder Armor triggers weapon proc as well as normal procs despite dealing no damage
-        if (m_caster->GetTypeId() == TYPEID_PLAYER && m_spellInfo->IsFitToFamilyMask<CF_WARRIOR_SUNDER_ARMOR>())
-            ((Player*)m_caster)->CastItemCombatSpell(unitTarget, BASE_ATTACK);
-
         // Fill base damage struct (unitTarget - is real spell target)
         SpellNonMeleeDamage damageInfo(caster, unitTarget, m_spellInfo->Id, GetFirstSchoolInMask(m_spellSchoolMask));
         procEx = createProcExtendMask(&damageInfo, missInfo);
@@ -1311,7 +1307,10 @@ void Spell::DoAllEffectOnTarget(TargetInfo *target)
         }
         caster->ProcDamageAndSpell(unit, real_caster ? procAttacker : PROC_FLAG_NONE, procVictim, procEx, dmg, m_attackType, m_spellInfo, this);
     }
-
+    // Sunder Armor triggers weapon proc as well as normal procs despite dealing no damage
+    if (m_caster->GetTypeId() == TYPEID_PLAYER && m_spellInfo->IsFitToFamilyMask<CF_WARRIOR_SUNDER_ARMOR>())
+            ((Player*)m_caster)->CastItemCombatSpell(unitTarget, BASE_ATTACK);
+    
     if (missInfo != SPELL_MISS_NONE)
         return;
 


### PR DESCRIPTION
Moved the Sunder Armor fix for triggering main hand weapon procs outside of a conditional statement that made it never execute.