### PR TITLE
Correct Lord Kazzak (ID: 12397) loot table

### DIFF
--- a/sql/migrations/20170818093600_world.sql
+++ b/sql/migrations/20170818093600_world.sql
@@ -1,0 +1,4 @@
+INSERT INTO `migrations` VALUES ('20170818093600'); 
+
+-- Add Fel Infused Leggings (ID: 19133) to Lord Kazzak (ID: 12397) loot table:
+INSERT INTO creature_loot_template VALUES (12397, 19133, 9.04, 0, 1, 1, 0);


### PR DESCRIPTION
Item "Fel Infused Leggings" (ID: 19133) from Lord Kazzak (ID: 12397) loot table is missing.

Fixes #2134 

See https://web.archive.org/web/20060307103001/http://wow.allakhazam.com:80/item.html?witem=19133