### PR TITLE
Allow Mac PPC clients to log in

### DIFF
--- a/src/realmd/AuthSocket.cpp
+++ b/src/realmd/AuthSocket.cpp
@@ -764,7 +764,7 @@ bool AuthSocket::_HandleLogonProof()
     }
 
     // reject credentials on unexpected build to confuse custom client authors
-    auto const approvedBuild = _platform == X86 && (_os == Win || _os == OSX);
+    auto const approvedBuild = (_platform == X86 || _platform == PPC) && (_os == Win || _os == OSX);
 
     ///- Check if SRP6 results match (password is correct), else send an error
     if (!memcmp(M.AsByteArray().data(), lp.M1, 20) && pinResult && approvedBuild)

--- a/src/realmd/AuthSocket.h
+++ b/src/realmd/AuthSocket.h
@@ -109,6 +109,7 @@ class AuthSocket: public BufferedSocket
         static constexpr uint32 OSX = 'OSX';
 
         static constexpr uint32 X86 = 'x86';
+        static constexpr uint32 PPC = 'PPC';
 
         uint32 _os;
         uint32 _platform;


### PR DESCRIPTION
Admittedly, there are few mac ppc users out there these days.  But Mangos seems to support it and Blizzard shipped ppc binaries all the way until Cata.

It's a small change and it works fine on my local server.