### PR TITLE
Using /who in a battleground should list only players in your instance.

### DIFF
--- a/src/game/Handlers/MiscHandler.cpp
+++ b/src/game/Handlers/MiscHandler.cpp
@@ -83,6 +83,17 @@ public:
     uint32 zoneids[10];                                     // 10 is client limit
     std::wstring str[4];                                    // 4 is client limit
     std::wstring wplayer_name, wguild_name;
+    bool isBattlegroundZoneId(uint32 zoneid)
+    {
+        switch (zoneid)
+        {
+            case 2597: // AV
+            case 3277: // WSG
+            case 3358: // AB
+                return true;
+        }
+        return false;
+    }
     void run()
     {
         WorldSession* sess = sWorld.FindSession(accountId);
@@ -166,7 +177,14 @@ public:
             {
                 if (zoneids[i] == pzoneid)
                 {
-                    z_show = true;
+                    // World of Warcraft Client Patch 1.7.0 (2005-09-13)
+                    // Using the / who command while in a Battleground instance will now only display players in your instance.
+                    const uint32 searcherzone = sess->GetPlayer()->GetZoneId();
+                    if (!isBattlegroundZoneId(searcherzone) || (searcherzone != pzoneid) || (sess->GetPlayer()->GetInstanceId() == pl->GetInstanceId()))
+                        z_show = true;
+                    else
+                        z_show = false;
+
                     break;
                 }
 

--- a/src/game/Handlers/MiscHandler.cpp
+++ b/src/game/Handlers/MiscHandler.cpp
@@ -180,7 +180,7 @@ public:
                     // World of Warcraft Client Patch 1.7.0 (2005-09-13)
                     // Using the / who command while in a Battleground instance will now only display players in your instance.
                     const uint32 searcherzone = sess->GetPlayer()->GetZoneId();
-                    if (!isBattlegroundZoneId(searcherzone) || (searcherzone != pzoneid) || (sess->GetPlayer()->GetInstanceId() == pl->GetInstanceId()))
+                    if ((searcherzone != pzoneid) || !isBattlegroundZoneId(searcherzone) || (sess->GetPlayer()->GetInstanceId() == pl->GetInstanceId()))
                         z_show = true;
                     else
                         z_show = false;


### PR DESCRIPTION
> World of Warcraft Client Patch 1.7.0 (2005-09-13)
> - Using the /who command while in a Battleground instance will now only display players in your instance. 

If you type /who while in a battleground, it should not list people who are not in the same battleground as you.