### PR TITLE
Fixes invisibility logic for creatures and players

### DIFF
--- a/src/game/Objects/Unit.cpp
+++ b/src/game/Objects/Unit.cpp
@@ -7518,8 +7518,8 @@ bool Unit::isVisibleForOrDetect(Unit const* u, WorldObject const* viewPoint, boo
             return bVisible;
     }
 
-    // Visible units, always are visible for all units, except for units under invisibility
-    if (m_Visibility == VISIBILITY_ON && u->m_invisibilityMask == 0)
+    // Visible units are always visible for all units
+    if (m_Visibility == VISIBILITY_ON)
         return true;
 
     // GMs see any players, not higher GMs and all units
@@ -7537,14 +7537,14 @@ bool Unit::isVisibleForOrDetect(Unit const* u, WorldObject const* viewPoint, boo
     // raw invisibility
     bool invisible = m_invisibilityMask != 0;
 
-    // detectable invisibility case
+    // Detectable invisibility case
     if (invisible && (
-                // Invisible units, always are visible for units under same invisibility type
-                m_invisibilityMask & u->m_invisibilityMask ||
-                // Invisible units, always are visible for unit that can detect this invisibility (have appropriate level for detect)
-                u->canDetectInvisibilityOf(this) ||
-                // Units that can detect invisibility always are visible for units that can be detected
-                canDetectInvisibilityOf(u)))
+            // Invisible units are always visible for units under same
+            // invisibility type
+            (m_invisibilityMask & u->m_invisibilityMask) ||
+            // Invisible units are always visible for units that can detect the
+            // appropriate invisibility level
+            u->canDetectInvisibilityOf(this)))
         invisible = false;
 
     // special cases for always overwrite invisibility/stealth
@@ -7638,10 +7638,7 @@ void Unit::SetVisibility(UnitVisibility x)
 
 bool Unit::canDetectInvisibilityOf(Unit const* u) const
 {
-    if (!u->m_invisibilityMask && m_detectInvisibilityMask)
-        return true;
-
-    if (const Creature* worldBoss = u->ToCreature())
+    if (const Creature* worldBoss = ToCreature())
         if (worldBoss->IsWorldBoss())
             return true;
 


### PR DESCRIPTION
Fixes #2052.

The logic prior to this change failed for rogues because of Detect Traps that added  bits to `m_detectInvisibilityMask`.

This change complements the reverted invisibility mechanic in [1].

I have tested it for the following cases:
- [x] World bosses can detect invisible units
- [x] Cannot detect units with Lesser Invisibility Potion nor Invisibility Potion
- [x] Can detect units with Lesser Invisibility Potion with Detect Lesser Invisibility and Detect Greater Invisibility
- [x] Can detect units with Invisibility Potion with Detect Greater Invisibility
- [x] Can detect units with the same invisibility type

[1] https://github.com/cmangos/mangos-classic/commit/379728f100cda84c5e67debe20712dabd4c29b5e