### PR TITLE
Fix to wrapped items not being saved to db

### DIFF
--- a/src/game/Handlers/ItemHandler.cpp
+++ b/src/game/Handlers/ItemHandler.cpp
@@ -1230,9 +1230,7 @@ void WorldSession::HandleWrapItemOpcode(WorldPacket& recv_data)
 
     if (item->GetState() == ITEM_NEW)                       // save new item, to have alway for `character_gifts` record in `item_instance`
     {
-        // after save it will be impossible to remove the item from the queue
-        item->RemoveFromUpdateQueueOf(_player);
-        item->SaveToDB();                                   // item gave inventory record unchanged and can be save standalone
+        _player->SaveInventoryAndGoldToDB();
     }
     CharacterDatabase.CommitTransaction();
 


### PR DESCRIPTION
Possibly fixes https://github.com/elysium-project/server/issues/2584 but his problem is different.

When wrapping an unsaved item, it was forcing a save on the _item_instance_ table but not on the _character_inventory_ table. The missing items still exist on the database, they're just not on any inventory.

Replaced the item save with an inventory save.