### PR TITLE
Fix for Otho Moji'kos Missing Quests for bug#2588

### DIFF
--- a/sql/migrations/20170916172553_world.sql
+++ b/sql/migrations/20170916172553_world.sql
@@ -1,5 +1,7 @@
+INSERT INTO `migrations` VALUES ('20170916172553');
+
 UPDATE quest_template
-SET ReqCreatureOrGoCount1 = 8, ReqCreatureOrGoCount2 = 5, ReqCreatureOrGoCount3 = 5, ReqCreatureOrGoCount4 = 2, Type = 0
+SET Type = 0
 WHERE entry = 7841;
 
 UPDATE creature_template

--- a/sql/migrations/20170916172553_world.sql
+++ b/sql/migrations/20170916172553_world.sql
@@ -1,0 +1,9 @@
+UPDATE quest_template
+SET ReqCreatureOrGoCount1 = 8, ReqCreatureOrGoCount2 = 5, ReqCreatureOrGoCount3 = 5, ReqCreatureOrGoCount4 = 2, Type = 0
+WHERE entry = 7841;
+
+UPDATE creature_template
+SET npcflag = 6
+WHERE ENTRY = 14738
+
+


### PR DESCRIPTION
Not sure if I submitted this correctly but fix for Bug #2588 

-Quest: Separation_Anxiety Was not able to replicate this issue, quest existed when I pulled the latest Database and Souce

-Quest: Message_To_the_WildHammer - Changed NPC Flag to 6 from 4(Vendor and Quest Giver), also updated the Type of quest as having it set to PvP was causing it not to show. Also updated the Objectives to the correct values. Previously every Objective was 15 kills when it should be 8/5/5/2.

Source: http://wowwiki.wikia.com/wiki/Quest:Message_to_the_Wildhammer