### PR TITLE
Changed MinLevel of Quests Dangerous! and Battle of Hillsbrad Bug #2552

### DIFF
--- a/sql/migrations/20170916211035_world.sql
+++ b/sql/migrations/20170916211035_world.sql
@@ -1,5 +1,7 @@
 UPDATE quest_template
 SET MinLevel = 19
-WHERE entry = 550
+WHERE entry = 550;
 
-
+UPDATE quest_template
+SET MinLevel = 19
+WHERE entry = 567;

--- a/sql/migrations/20170916211035_world.sql
+++ b/sql/migrations/20170916211035_world.sql
@@ -1,7 +1,3 @@
 UPDATE quest_template
 SET MinLevel = 19
-WHERE entry = 550;
-
-UPDATE quest_template
-SET MinLevel = 19
-WHERE entry = 567;
+WHERE entry = 550 OR entry = 567 OR entry = 539 OR entry = 532 OR entry = 528 OR entry = 541 OR entry = 529 OR entry = 527;

--- a/sql/migrations/20170916211035_world.sql
+++ b/sql/migrations/20170916211035_world.sql
@@ -1,0 +1,5 @@
+UPDATE quest_template
+SET MinLevel = 19
+WHERE entry = 550
+
+

--- a/sql/migrations/20170916211035_world.sql
+++ b/sql/migrations/20170916211035_world.sql
@@ -1,3 +1,5 @@
+INSERT INTO `migrations` VALUES ('20170916211035');
+
 UPDATE quest_template
 SET MinLevel = 19
 WHERE entry = 550 OR entry = 567 OR entry = 539 OR entry = 532 OR entry = 528 OR entry = 541 OR entry = 529 OR entry = 527;


### PR DESCRIPTION
Bug: #2552 
Changed the MinLevel of Quests: Dangerous! and Battle of Hillsbrad.

Battle of Hillsbrad - Found comment by battery on 2007/12/22 that syas Just did the Q in 2.3 it's still possible to get this at level 19. 

Dangerous! - WoWHead says you were able to get the quest at 17 but a comment from 2007/02/23 by phoboss that says The required level is 19 not 17. Got the bow for my hunter with a little help from a guildmate ;) Really good for level 19.. 

Sources:
http://www.wowhead.com/quest=567/deprecated-dangerous
http://www.wowhead.com/quest=527/deprecated-battle-of-hillsbrad
http://www.wowhead.com/quest=528/deprecated-battle-of-hillsbrad
http://www.wowhead.com/quest=529/deprecated-battle-of-hillsbrad
http://www.wowhead.com/quest=532/deprecated-battle-of-hillsbrad
http://www.wowhead.com/quest=539/deprecated-battle-of-hillsbrad
http://www.wowhead.com/quest=541/deprecated-battle-of-hillsbrad
http://www.wowhead.com/quest=550/deprecated-battle-of-hillsbrad
