### PR TITLE
Use smarter query for adding migrations.

### DIFF
--- a/sql/make_migration.bat
+++ b/sql/make_migration.bat
@@ -27,6 +27,7 @@ ECHO END IF;>> migrations/%output%
 ECHO END;>> migrations/%output%
 ECHO ^|>> migrations/%output%
 ECHO CALL add_migration;>> migrations/%output%
+ECHO DROP PROCEDURE IF EXISTS add_migration;>> migrations/%output%
 
 REM End of the script Body
 :EndOfScriptBody

--- a/sql/make_migration.bat
+++ b/sql/make_migration.bat
@@ -10,7 +10,23 @@ ECHO "Formatted UTC Date time : %UTC%"
 
 SET "output=%UTC%_world.sql"
 
-ECHO INSERT INTO `migrations` VALUES ('%UTC%'); >> migrations/%output%
+ECHO DELIMITER ^|>> migrations/%output%
+ECHO DROP PROCEDURE IF EXISTS add_migration;>> migrations/%output%
+ECHO CREATE PROCEDURE add_migration()>> migrations/%output%
+ECHO BEGIN>> migrations/%output%
+ECHO DECLARE v INT DEFAULT 1;>> migrations/%output%
+ECHO SET v = (SELECT COUNT(*) FROM `migrations` WHERE `id`='%UTC%');>> migrations/%output%
+ECHO IF v=0 THEN>> migrations/%output%
+ECHO INSERT INTO `migrations` VALUES ('%UTC%');>> migrations/%output%
+ECHO -- Add your query below.>> migrations/%output%
+ECHO.>> migrations/%output%
+ECHO.>> migrations/%output%
+ECHO.>> migrations/%output%
+ECHO -- End of migration.>> migrations/%output%
+ECHO END IF;>> migrations/%output%
+ECHO END;>> migrations/%output%
+ECHO ^|>> migrations/%output%
+ECHO CALL add_migration;>> migrations/%output%
 
 REM End of the script Body
 :EndOfScriptBody

--- a/sql/touch_migration.sh
+++ b/sql/touch_migration.sh
@@ -4,7 +4,7 @@ FPATH=migrations/"$DATE"_world.sql
 touch "$FPATH"
 
 if [ -e "$FPATH" ]; then
-	echo -e "INSERT INTO \`migrations\` VALUES ('$DATE');" > $FPATH
+	echo -e "DELIMITER |\r\nDROP PROCEDURE IF EXISTS add_migration;\r\nCREATE PROCEDURE add_migration()\r\nBEGIN\r\nDECLARE v INT DEFAULT 1;\r\nSET v = (SELECT COUNT(*) FROM \`migrations\` WHERE \`id\`='$DATE');\r\nIF v=0 THEN\r\nINSERT INTO \`migrations\` VALUES ('$DATE');\r\n-- Add your query below.\r\n\r\n\r\n\r\n-- End of migration.\r\nEND IF;\r\nEND;\r\n|\r\nCALL add_migration;" > $FPATH
 
 else 
 	echo "FAILED to create file"

--- a/sql/touch_migration.sh
+++ b/sql/touch_migration.sh
@@ -4,7 +4,7 @@ FPATH=migrations/"$DATE"_world.sql
 touch "$FPATH"
 
 if [ -e "$FPATH" ]; then
-	echo -e "DELIMITER |\r\nDROP PROCEDURE IF EXISTS add_migration;\r\nCREATE PROCEDURE add_migration()\r\nBEGIN\r\nDECLARE v INT DEFAULT 1;\r\nSET v = (SELECT COUNT(*) FROM \`migrations\` WHERE \`id\`='$DATE');\r\nIF v=0 THEN\r\nINSERT INTO \`migrations\` VALUES ('$DATE');\r\n-- Add your query below.\r\n\r\n\r\n\r\n-- End of migration.\r\nEND IF;\r\nEND;\r\n|\r\nCALL add_migration;" > $FPATH
+	echo -e "DELIMITER |\r\nDROP PROCEDURE IF EXISTS add_migration;\r\nCREATE PROCEDURE add_migration()\r\nBEGIN\r\nDECLARE v INT DEFAULT 1;\r\nSET v = (SELECT COUNT(*) FROM \`migrations\` WHERE \`id\`='$DATE');\r\nIF v=0 THEN\r\nINSERT INTO \`migrations\` VALUES ('$DATE');\r\n-- Add your query below.\r\n\r\n\r\n\r\n-- End of migration.\r\nEND IF;\r\nEND;\r\n|\r\nCALL add_migration;\r\nDROP PROCEDURE IF EXISTS add_migration;" > $FPATH
 
 else 
 	echo "FAILED to create file"


### PR DESCRIPTION
This makes it so migrations cannot be run twice with errors disabled. It will prevent duplication. If all migrations are made with it, you will be able to run "world_db_updates.sql" on a db that already has some of the migrations and it will only add those that are missing. You wont have to manually check which migrations are missing and run them individually one by one to update your database anymore. 

Here is how migrations created with the batch file will look:
```
DELIMITER |
DROP PROCEDURE IF EXISTS add_migration;
CREATE PROCEDURE add_migration()
BEGIN
DECLARE v INT DEFAULT 1;
SET v = (SELECT COUNT(*) FROM `migrations` WHERE `id`='20170920135331');
IF v=0 THEN
INSERT INTO `migrations` VALUES ('20170920135331');
-- Add your query below.



-- End of migration.
END IF;
END;
|
CALL add_migration;
```