### PR TITLE
Make sure swing timer is reset at end of cast.

### DIFF
--- a/src/game/Spells/Spell.cpp
+++ b/src/game/Spells/Spell.cpp
@@ -3494,6 +3494,13 @@ void Spell::cast(bool skipCheck)
         }
     }
 
+    if (IsMeleeAttackResetSpell() && !(m_spellInfo->AttributesEx2 & SPELL_ATTR_EX2_NOT_RESET_AUTO_ACTIONS))
+    {
+        m_caster->resetAttackTimer(BASE_ATTACK);
+        if (m_caster->haveOffhandWeapon())
+            m_caster->resetAttackTimer(OFF_ATTACK);
+    }
+
     m_caster->DecreaseCastCounter();
     SetExecutedCurrently(false);
 }


### PR DESCRIPTION
The problem was that Spell::finish(), where the reset timer is reset, was called AFTER the unit was already made able to attack, so resetting it there didn't accomplish anything in some situations. Now auto attack will no longer go off immediately after finishing a cast.