### PR TITLE
Now delay far teleports until the map update is complete

### DIFF
--- a/src/game/Handlers/CharacterHandler.cpp
+++ b/src/game/Handlers/CharacterHandler.cpp
@@ -651,6 +651,8 @@ void WorldSession::HandlePlayerLogin(LoginQueryHolder *holder)
             pCurrChar->TeleportTo(at->target_mapId, at->target_X, at->target_Y, at->target_Z, pCurrChar->GetOrientation());
         else
             pCurrChar->TeleportToHomebind();
+
+        sMapMgr.ExecuteSingleDelayedTeleport(pCurrChar);
     }
 
     if (alreadyOnline)

--- a/src/game/Maps/MapManager.cpp
+++ b/src/game/Maps/MapManager.cpp
@@ -298,6 +298,10 @@ void MapManager::Update(uint32 diff)
     if (!i_timer.Passed())
         return;
 
+    // Execute any teleports scheduled in the main thread prior to map update
+    // eg. area triggers, world port acks
+    ExecuteDelayedPlayerTeleports();
+
     uint32 mapsDiff = (uint32)i_timer.GetCurrent();
     bool updateFinished = false;
     std::vector<MapAsyncUpdater*> instanceUpdaters(sWorld.getConfig(CONFIG_UINT32_MAPUPDATE_INSTANCED_UPDATE_THREADS));
@@ -828,20 +832,50 @@ uint32 MapManager::GetContinentInstanceId(uint32 mapId, float x, float y, bool* 
 void MapManager::ScheduleFarTeleport(Player *player, ScheduledTeleportData *data)
 {
     ACE_Guard<ACE_Thread_Mutex> guard(m_scheduledFarTeleportsLock);
+    player->SetSemaphoreTeleportFar(true);
     m_scheduledFarTeleports[player] = data;
 }
 
+// Execute all delayed teleports at the end of a map update
 void MapManager::ExecuteDelayedPlayerTeleports()
 {
-    std::map<Player*, ScheduledTeleportData*>::iterator iter;
+    ScheduledTeleportMap::iterator iter;
     for (iter = m_scheduledFarTeleports.begin(); iter != m_scheduledFarTeleports.end(); ++iter)
     {
-        // Delete the scheduled teleport data so we're not leaking
-        iter->first->ExecuteTeleportFar(iter->second);
-        delete iter->second;
+        ExecuteSingleDelayedTeleport(iter);
     }
 
     m_scheduledFarTeleports.clear();
+}
+
+// Execute a single delayed teleport for the given player (if there are any). It should
+// only be necessary to call this in teleports performed outside of an update (i.e.
+// player logout and login).
+void MapManager::ExecuteSingleDelayedTeleport(Player *player)
+{
+    ACE_Guard<ACE_Thread_Mutex> guard(m_scheduledFarTeleportsLock);
+    ScheduledTeleportMap::iterator iter = m_scheduledFarTeleports.find(player);
+
+    if (iter != m_scheduledFarTeleports.end())
+    {
+        ExecuteSingleDelayedTeleport(iter);
+
+        m_scheduledFarTeleports.erase(iter);
+    }
+}
+
+void MapManager::ExecuteSingleDelayedTeleport(ScheduledTeleportMap::iterator iter)
+{
+    // Execute the teleport. If it fails, clear the semaphore
+    if (!iter->first->ExecuteTeleportFar(iter->second))
+        iter->first->SetSemaphoreTeleportFar(false);
+    delete iter->second; // don't leak tele data
+}
+
+void MapManager::CancelDelayedPlayerTeleport(Player *player)
+{
+    ACE_Guard<ACE_Thread_Mutex> guard(m_scheduledFarTeleportsLock);
+    m_scheduledFarTeleports.erase(player);
 }
 
 void MapManager::ScheduleInstanceSwitch(Player* player, uint16 newInstance)

--- a/src/game/Maps/MapManager.h
+++ b/src/game/Maps/MapManager.h
@@ -72,6 +72,8 @@ struct MANGOS_DLL_DECL MapID
     uint32 nInstanceId;
 };
 
+struct ScheduledTeleportData;
+
 class MANGOS_DLL_DECL MapManager : public MaNGOS::Singleton<MapManager, MaNGOS::ClassLevelLockable<MapManager, ACE_Recursive_Thread_Mutex> >
 {
     friend class MaNGOS::OperatorNew<MapManager>;
@@ -178,6 +180,9 @@ class MANGOS_DLL_DECL MapManager : public MaNGOS::Singleton<MapManager, MaNGOS::
         void ScheduleInstanceSwitch(Player* player, uint16 newInstance);
         void SwitchPlayersInstances();
 
+        void ScheduleFarTeleport(Player *player, ScheduledTeleportData *data);
+        void ExecuteDelayedPlayerTeleports();
+
         void MarkContinentUpdateFinished(int idx)
         {
             ASSERT(idx < i_maxContinentThread);
@@ -228,6 +233,9 @@ class MANGOS_DLL_DECL MapManager : public MaNGOS::Singleton<MapManager, MaNGOS::
         const static int LAST_CONTINENT_ID = 2;
         ACE_Thread_Mutex    m_scheduledInstanceSwitches_lock[LAST_CONTINENT_ID];
         std::map<Player*, uint16 /* new instance */> m_scheduledInstanceSwitches[LAST_CONTINENT_ID]; // 2 continents
+
+        ACE_Thread_Mutex m_scheduledFarTeleportsLock;
+        std::map<Player*, ScheduledTeleportData*> m_scheduledFarTeleports;
 };
 
 template<typename Do>

--- a/src/game/Maps/MapManager.h
+++ b/src/game/Maps/MapManager.h
@@ -182,6 +182,8 @@ class MANGOS_DLL_DECL MapManager : public MaNGOS::Singleton<MapManager, MaNGOS::
 
         void ScheduleFarTeleport(Player *player, ScheduledTeleportData *data);
         void ExecuteDelayedPlayerTeleports();
+        void ExecuteSingleDelayedTeleport(Player *player);
+        void CancelDelayedPlayerTeleport(Player *player);
 
         void MarkContinentUpdateFinished(int idx)
         {
@@ -235,7 +237,10 @@ class MANGOS_DLL_DECL MapManager : public MaNGOS::Singleton<MapManager, MaNGOS::
         std::map<Player*, uint16 /* new instance */> m_scheduledInstanceSwitches[LAST_CONTINENT_ID]; // 2 continents
 
         ACE_Thread_Mutex m_scheduledFarTeleportsLock;
-        std::map<Player*, ScheduledTeleportData*> m_scheduledFarTeleports;
+        typedef std::map<Player*, ScheduledTeleportData*> ScheduledTeleportMap;
+        ScheduledTeleportMap m_scheduledFarTeleports;
+
+        void ExecuteSingleDelayedTeleport(ScheduledTeleportMap::iterator iter);
 };
 
 template<typename Do>

--- a/src/game/Objects/Object.cpp
+++ b/src/game/Objects/Object.cpp
@@ -1328,6 +1328,20 @@ bool WorldObject::IsWithinDist2d(float x, float y, float dist2compare) const
     return distsq < maxdist * maxdist;
 }
 
+bool WorldObject::IsInMap(const WorldObject* obj) const
+{
+    // IsInWorld() is not thread safe, but FindMap() is. Technically we can
+    // have a race condition where the unit is in the world, but by the time
+    // we check the map they have been removed (eg. when checking players
+    // within the same group across maps, or checking whether the player can
+    // receive loot). Therefore, we use FindMap() rather than GetMap(), which
+    // allows the map to be null and hence not be in the same map as this
+    // object.
+    // Further note that ADDING players to a map is done synchronously in the
+    // main thread, but removing is not.
+    return IsInWorld() && obj->IsInWorld() && (FindMap() == obj->FindMap());
+}
+
 bool WorldObject::_IsWithinDist(WorldObject const* obj, float dist2compare, bool is3D) const
 {
     ASSERT(obj);

--- a/src/game/Objects/Object.cpp
+++ b/src/game/Objects/Object.cpp
@@ -2017,6 +2017,7 @@ bool WorldObject::isWithinVisibilityDistanceOf(Unit const* viewer, WorldObject c
 void WorldObject::SetMap(Map * map)
 {
     MANGOS_ASSERT(map);
+    ACE_Guard<ACE_Thread_Mutex> guard(currMapLock);
     m_currMap = map;
     //lets save current map's Id/instanceId
     m_mapId = map->GetId();
@@ -2026,14 +2027,23 @@ void WorldObject::SetMap(Map * map)
     SetZoneScript();
 }
 
+Map* WorldObject::GetMap() const
+{
+    ACE_Guard<ACE_Thread_Mutex> guard(currMapLock);
+    MANGOS_ASSERT(m_currMap);
+    return m_currMap;
+}
+
 void WorldObject::ResetMap()
 {
+    ACE_Guard<ACE_Thread_Mutex> guard(currMapLock);
     m_currMap = nullptr;
     m_zoneScript = nullptr;
 }
 
 TerrainInfo const* WorldObject::GetTerrain() const
 {
+    ACE_Guard<ACE_Thread_Mutex> guard(currMapLock);
     MANGOS_ASSERT(m_currMap);
     return m_currMap->GetTerrain();
 }

--- a/src/game/Objects/Object.h
+++ b/src/game/Objects/Object.h
@@ -739,15 +739,7 @@ m_obj->m_updateTracker.Reset();
         float GetDistance2d(float x, float y) const;
         float GetDistanceZ(const WorldObject* obj) const;
         float GetDistanceSqr(float x, float y, float z) const;
-        bool IsInMap(const WorldObject* obj) const
-        {
-            return IsInWorld() && obj->IsInWorld() && (GetMap() == obj->GetMap());
-        }
-        // Check same map without asserting m_currMap is valid (allow NULL map)
-        bool IsInMapDirect(const WorldObject* obj) const
-        {
-            return IsInWorld() && obj->IsInWorld() && (FindMap() == obj->FindMap());
-        }
+        bool IsInMap(const WorldObject* obj) const;
         bool IsWithinDist3d(float x, float y, float z, float dist2compare) const;
         bool IsWithinDist2d(float x, float y, float dist2compare) const;
         bool _IsWithinDist(WorldObject const* obj, float dist2compare, bool is3D) const;

--- a/src/game/Objects/Object.h
+++ b/src/game/Objects/Object.h
@@ -858,7 +858,7 @@ m_obj->m_updateTracker.Reset();
 
         void SetMap(Map * map);
         Map * GetMap() const;
-        Map * FindMap() const { ACE_Guard<ACE_Thread_Mutex> guard(currMapLock); return m_currMap; }
+        Map * FindMap() const { return m_currMap; }
 
         //used to check all object's GetMap() calls when object is not in world!
         void ResetMap();
@@ -921,7 +921,6 @@ m_obj->m_updateTracker.Reset();
         ZoneScript* m_zoneScript;
         bool m_isActiveObject;
 
-        mutable ACE_Thread_Mutex currMapLock;               // mutex acquired when looking up or changing the current map
         Map * m_currMap;                                    //current object's Map location
 
         uint32 m_mapId;                                     // object at map with map_id

--- a/src/game/Objects/Object.h
+++ b/src/game/Objects/Object.h
@@ -743,6 +743,11 @@ m_obj->m_updateTracker.Reset();
         {
             return IsInWorld() && obj->IsInWorld() && (GetMap() == obj->GetMap());
         }
+        // Check same map without asserting m_currMap is valid (allow NULL map)
+        bool IsInMapDirect(const WorldObject* obj) const
+        {
+            return IsInWorld() && obj->IsInWorld() && (FindMap() == obj->FindMap());
+        }
         bool IsWithinDist3d(float x, float y, float z, float dist2compare) const;
         bool IsWithinDist2d(float x, float y, float dist2compare) const;
         bool _IsWithinDist(WorldObject const* obj, float dist2compare, bool is3D) const;
@@ -860,8 +865,8 @@ m_obj->m_updateTracker.Reset();
         virtual bool isVisibleForInState(Player const* u, WorldObject const* viewPoint, bool inVisibleList) const = 0;
 
         void SetMap(Map * map);
-        Map * GetMap() const { MANGOS_ASSERT(m_currMap); return m_currMap; }
-        Map * FindMap() const { return m_currMap; }
+        Map * GetMap() const;
+        Map * FindMap() const { ACE_Guard<ACE_Thread_Mutex> guard(currMapLock); return m_currMap; }
 
         //used to check all object's GetMap() calls when object is not in world!
         void ResetMap();
@@ -924,6 +929,7 @@ m_obj->m_updateTracker.Reset();
         ZoneScript* m_zoneScript;
         bool m_isActiveObject;
 
+        mutable ACE_Thread_Mutex currMapLock;               // mutex acquired when looking up or changing the current map
         Map * m_currMap;                                    //current object's Map location
 
         uint32 m_mapId;                                     // object at map with map_id

--- a/src/game/Objects/Player.cpp
+++ b/src/game/Objects/Player.cpp
@@ -18222,7 +18222,7 @@ bool Player::HasQuestForGO(int32 GOId) const
 void Player::UpdateForQuestWorldObjects()
 {
     // Don't process updates if we're not in the world (map is NULL)
-    if (!IsInWorld())
+    if (!IsInWorld() || !FindMap())
         return;
 
     uint32 count = 0;

--- a/src/game/Objects/Player.cpp
+++ b/src/game/Objects/Player.cpp
@@ -2096,9 +2096,11 @@ bool Player::ExecuteTeleportFar(ScheduledTeleportData *data)
                 m_teleportRecover = wps;
             wps();
         }
+
+        return true;
     }
-    else
-        return false;
+
+    return false;
 }
 
 void Player::restorePendingTeleport()

--- a/src/game/Objects/Player.cpp
+++ b/src/game/Objects/Player.cpp
@@ -1868,6 +1868,7 @@ bool Player::TeleportTo(uint32 mapid, float x, float y, float z, float orientati
     if (!(options & TELE_TO_NOT_LEAVE_TRANSPORT) || !m_transport)
         m_movementInfo.RemoveMovementFlag(MOVEFLAG_ONTRANSPORT);
 
+    // Near teleport, let it happen immediately since we remain in the same map
     if ((GetMapId() == mapid) && (!m_transport) && !(options & TELE_TO_FORCE_MAP_CHANGE))
     {
         //lets reset far teleport flag if it wasn't reset during chained teleports
@@ -1932,7 +1933,6 @@ bool Player::TeleportTo(uint32 mapid, float x, float y, float z, float orientati
     }
     else
     {
-        // far teleport to another map
         Map* oldmap = IsInWorld() ? GetMap() : NULL;
         // check if we can enter before stopping combat / removing pet / totems / interrupting spells
 
@@ -1941,140 +1941,148 @@ bool Player::TeleportTo(uint32 mapid, float x, float y, float z, float orientati
         if (!sMapMgr.CanPlayerEnter(mapid, this))
             return false;
 
-        // If the map is not created, assume it is possible to enter it.
-        // It will be created in the WorldPortAck.
-        DungeonPersistentState* state = GetBoundInstanceSaveForSelfOrGroup(mapid);
-        uint32 instanceId = 0;
-        if (state)
-            instanceId = state->GetInstanceId();
-        if (mapid <= 1)
-            instanceId = sMapMgr.GetContinentInstanceId(mapid, x, y);
-        Map *map = sMapMgr.FindMap(mapid, instanceId);
-        if (!map || map->CanEnter(this))
+        // Far teleport to another map. We can't do this right now since it means
+        // we need to remove from this map mid-update. Instead, schedule it for
+        // after updates are complete
+        ScheduledTeleportData *data = new ScheduledTeleportData(mapid, x, y, z, orientation, options, recover);
+
+        sMapMgr.ScheduleFarTeleport(this, data);
+    }
+    return true;
+}
+
+bool Player::ExecuteTeleportFar(ScheduledTeleportData *data)
+{
+    Map* oldmap = IsInWorld() ? GetMap() : NULL;
+    // check if we can enter before stopping combat / removing pet / totems / interrupting spells
+
+    // Check enter rights before map getting to avoid creating instance copy for player
+    // this check not dependent from map instance copy and same for all instance copies of selected map
+    uint32 mapid = data->targetMapId;
+    if (!sMapMgr.CanPlayerEnter(mapid, this))
+        return false;
+
+    // If the map is not created, assume it is possible to enter it.
+    // It will be created in the WorldPortAck.
+    DungeonPersistentState* state = GetBoundInstanceSaveForSelfOrGroup(mapid);
+    uint32 instanceId = 0;
+    if (state)
+        instanceId = state->GetInstanceId();
+    if (mapid <= 1)
+        instanceId = sMapMgr.GetContinentInstanceId(mapid, data->x, data->y);
+    Map *map = sMapMgr.FindMap(mapid, instanceId);
+    if (!map || map->CanEnter(this))
+    {
+        //lets reset near teleport flag if it wasn't reset during chained teleports
+        SetSemaphoreTeleportNear(false);
+
+        SetSelectionGuid(ObjectGuid());
+        CombatStop();
+        ResetContestedPvP();
+        RemoveAurasWithInterruptFlags(AURA_INTERRUPT_FLAG_TELEPORTED);
+
+        // reset extraAttack counter
+        ResetExtraAttacks();
+
+        /*
+        * Fix exploit:
+        * 1. Use summoning ritual to teleport a player
+        * 2. The teleported player tp to homebind <- Should remove teleport invitation
+        * 3. And accepts teleport to come back to the instance
+        */
+        m_summon_expire = 0;
+
+        // remove player from battleground on far teleport (when changing maps)
+        if (BattleGround const* bg = GetBattleGround())
         {
-            //lets reset near teleport flag if it wasn't reset during chained teleports
-            SetSemaphoreTeleportNear(false);
-            //setup delayed teleport flag
-            //if teleport spell is casted in Unit::Update() func
-            //then we need to delay it until update process will be finished
-            if (SetDelayedTeleportFlagIfCan())
+            // Note: at battleground join battleground id set before teleport
+            // and we already will found "current" battleground
+            // just need check that this is targeted map or leave
+            if (bg->GetMapId() != mapid)
+                LeaveBattleground(false);                   // don't teleport to entry point
+        }
+
+        // remove pet on map change
+        Pet* pet = GetPet();
+        if (pet)
+            UnsummonPetTemporaryIfAny();
+
+        // remove all dyn objects
+        RemoveAllDynObjects();
+
+        // stop spellcasting
+        // not attempt interrupt teleportation spell at caster teleport
+        if (!(data->options & TELE_TO_SPELL))
+            if (IsNonMeleeSpellCasted(true))
+                InterruptNonMeleeSpells(true);
+
+        //remove auras before removing from map...
+        RemoveAurasWithInterruptFlags(AURA_INTERRUPT_FLAG_CHANGE_MAP | AURA_INTERRUPT_FLAG_MOVE | AURA_INTERRUPT_FLAG_TURNING);
+        RemoveSpellsCausingAura(SPELL_AURA_MOD_CHARM);
+        RemoveSpellsCausingAura(SPELL_AURA_MOD_POSSESS);
+
+        if (!GetSession()->PlayerLogout())
+        {
+            // send transfer packet to display load screen
+            WorldPacket data(SMSG_TRANSFER_PENDING, (4 + 4 + 4));
+            data << uint32(mapid);
+            if (m_transport)
             {
-                SetSemaphoreTeleportFar(true);
-                //lets save teleport destination for player
-                m_teleport_dest = WorldLocation(mapid, x, y, z, orientation);
-                m_teleport_options = options;
-                m_teleportRecoverDelayed = recover;
-                return true;
+                data << uint32(m_transport->GetEntry());
+                data << uint32(GetMapId());
             }
+            GetSession()->SendPacket(&data);
+        }
 
-            SetSelectionGuid(ObjectGuid());
-            CombatStop();
-            ResetContestedPvP();
-            RemoveAurasWithInterruptFlags(AURA_INTERRUPT_FLAG_TELEPORTED);
+        // remove from old map now
+        if (oldmap)
+            oldmap->Remove(this, false);
 
-            // reset extraAttack counter
-            ResetExtraAttacks();
+        m_teleport_dest = WorldLocation(mapid, data->x, data->y, data->z, data->orientation);
+        DisableSpline();
+        SetFallInformation(0, data->z);
+        ScheduleDelayedOperation(DELAYED_CAST_HONORLESS_TARGET);
 
-            /*
-             * Fix exploit:
-             * 1. Use summoning ritual to teleport a player
-             * 2. The teleported player tp to homebind <- Should remove teleport invitation
-             * 3. And accepts teleport to come back to the instance
-             */
-            m_summon_expire = 0;
+        // if the player is saved before worldport ack (at logout for example)
+        // this will be used instead of the current location in SaveToDB
 
-            // remove player from battleground on far teleport (when changing maps)
-            if (BattleGround const* bg = GetBattleGround())
-            {
-                // Note: at battleground join battleground id set before teleport
-                // and we already will found "current" battleground
-                // just need check that this is targeted map or leave
-                if (bg->GetMapId() != mapid)
-                    LeaveBattleground(false);                   // don't teleport to entry point
-            }
+        // move packet sent by client always after far teleport
+        // code for finish transfer to new map called in WorldSession::HandleMoveWorldportAckOpcode at client packet
+        SetSemaphoreTeleportFar(true);
 
-            // remove pet on map change
-            if (pet)
-                UnsummonPetTemporaryIfAny();
-
-            // remove all dyn objects
-            RemoveAllDynObjects();
-
-            // stop spellcasting
-            // not attempt interrupt teleportation spell at caster teleport
-            if (!(options & TELE_TO_SPELL))
-                if (IsNonMeleeSpellCasted(true))
-                    InterruptNonMeleeSpells(true);
-
-            //remove auras before removing from map...
-            RemoveAurasWithInterruptFlags(AURA_INTERRUPT_FLAG_CHANGE_MAP | AURA_INTERRUPT_FLAG_MOVE | AURA_INTERRUPT_FLAG_TURNING);
-            RemoveSpellsCausingAura(SPELL_AURA_MOD_CHARM);
-            RemoveSpellsCausingAura(SPELL_AURA_MOD_POSSESS);
-
-            if (!GetSession()->PlayerLogout())
-            {
-                // send transfer packet to display load screen
-                WorldPacket data(SMSG_TRANSFER_PENDING, (4 + 4 + 4));
+        if (!GetSession()->PlayerLogout())
+        {
+            const auto wps = [this, mapid]() {
+                // transfer finished, inform client to start load
+                WorldPacket data(SMSG_NEW_WORLD, (20));
                 data << uint32(mapid);
                 if (m_transport)
                 {
-                    data << uint32(m_transport->GetEntry());
-                    data << uint32(GetMapId());
+                    data << m_movementInfo.GetTransportPos()->x;
+                    data << m_movementInfo.GetTransportPos()->y;
+                    data << m_movementInfo.GetTransportPos()->z;
+                    data << m_movementInfo.GetTransportPos()->o;
+                }
+                else
+                {
+                    data << m_teleport_dest.coord_x;
+                    data << m_teleport_dest.coord_y;
+                    data << m_teleport_dest.coord_z;
+                    data << m_teleport_dest.orientation;
                 }
                 GetSession()->SendPacket(&data);
-            }
-
-            // remove from old map now
-            if (oldmap)
-                oldmap->Remove(this, false);
-
-            m_teleport_dest = WorldLocation(mapid, x, y, z, orientation);
-            DisableSpline();
-            SetFallInformation(0, z);
-            ScheduleDelayedOperation(DELAYED_CAST_HONORLESS_TARGET);
-
-            // if the player is saved before worldport ack (at logout for example)
-            // this will be used instead of the current location in SaveToDB
-
-            // move packet sent by client always after far teleport
-            // code for finish transfer to new map called in WorldSession::HandleMoveWorldportAckOpcode at client packet
-            SetSemaphoreTeleportFar(true);
-
-            if (!GetSession()->PlayerLogout())
-            {
-                const auto wps = [this, mapid](){
-                    // transfer finished, inform client to start load
-                    WorldPacket data(SMSG_NEW_WORLD, (20));
-                    data << uint32(mapid);
-                    if (m_transport)
-                    {
-                        data << m_movementInfo.GetTransportPos()->x;
-                        data << m_movementInfo.GetTransportPos()->y;
-                        data << m_movementInfo.GetTransportPos()->z;
-                        data << m_movementInfo.GetTransportPos()->o;
-                    }
-                    else
-                    {
-                        data << m_teleport_dest.coord_x;
-                        data << m_teleport_dest.coord_y;
-                        data << m_teleport_dest.coord_z;
-                        data << m_teleport_dest.orientation;
-                    }
-                    GetSession()->SendPacket(&data);
-                    SendMovementMessageToSet(std::move(data), true);
-                    SendSavedInstances();
-                };
-                if (recover)
-                    m_teleportRecover = recover;
-                else
-                    m_teleportRecover = wps;
-                wps();
-            }
+                SendMovementMessageToSet(std::move(data), true);
+                SendSavedInstances();
+            };
+            if (data->recover)
+                m_teleportRecover = data->recover;
+            else
+                m_teleportRecover = wps;
+            wps();
         }
-        else
-            return false;
     }
-    return true;
+    else
+        return false;
 }
 
 void Player::restorePendingTeleport()
@@ -13409,15 +13417,8 @@ void Player::GroupEventFailHappens(uint32 questId)
         {
             Player* pGroupGuy = itr->getSource();
             
-            // Fail regardless of distance, but only for players in the same map
-            // We MUST restrict it to the same map as it adds some modicum of thread
-            // safety (player in another map changes map or does other quest related
-            // changes at the same time = bad). Without this, there exists a race
-            // condition where the map can be NULL in UpdateForQuestWorldObjects()
-            // and we crash.
-            // Players in the same map don't experience this, and players changing
-            // between other maps will fail the check if the map is NULL or different.
-            if (pGroupGuy && pGroupGuy->IsInMap(this) && pGroupGuy->GetQuestStatus(questId) == QUEST_STATUS_INCOMPLETE)
+            // Fail regardless of distance
+            if (pGroupGuy && pGroupGuy->GetQuestStatus(questId) == QUEST_STATUS_INCOMPLETE)
                 pGroupGuy->FailQuest(questId);
         }
     }
@@ -18218,7 +18219,6 @@ bool Player::HasQuestForGO(int32 GOId) const
     return false;
 }
 
-// Not multithreaded
 void Player::UpdateForQuestWorldObjects()
 {
     // Don't process updates if we're not in the world (map is NULL)
@@ -18227,6 +18227,7 @@ void Player::UpdateForQuestWorldObjects()
 
     uint32 count = 0;
     UpdateData upd;
+    m_visibleGUIDs_lock.acquire_read();
     for (ObjectGuidSet::const_iterator itr = m_visibleGUIDs.begin(); itr != m_visibleGUIDs.end(); ++itr)
     {
         if (itr->IsGameObject())
@@ -18240,6 +18241,7 @@ void Player::UpdateForQuestWorldObjects()
                     }
         }
     }
+    m_visibleGUIDs_lock.release();
     if (count)
         upd.Send(GetSession());
 }

--- a/src/game/Objects/Player.cpp
+++ b/src/game/Objects/Player.cpp
@@ -13417,7 +13417,7 @@ void Player::GroupEventFailHappens(uint32 questId)
             // and we crash.
             // Players in the same map don't experience this, and players changing
             // between other maps will fail the check if the map is NULL or different.
-            if (pGroupGuy && pGroupGuy->IsInMapDirect(this) && pGroupGuy->GetQuestStatus(questId) == QUEST_STATUS_INCOMPLETE)
+            if (pGroupGuy && pGroupGuy->IsInMap(this) && pGroupGuy->GetQuestStatus(questId) == QUEST_STATUS_INCOMPLETE)
                 pGroupGuy->FailQuest(questId);
         }
     }

--- a/src/game/Objects/Player.cpp
+++ b/src/game/Objects/Player.cpp
@@ -470,6 +470,7 @@ Player::Player(WorldSession *session) : Unit(),
 
     mSemaphoreTeleport_Near = false;
     mSemaphoreTeleport_Far = false;
+    mPendingFarTeleport = false;
 
     m_DelayedOperations = 0;
     m_bCanDelayTeleport = false;

--- a/src/game/Objects/Player.h
+++ b/src/game/Objects/Player.h
@@ -832,6 +832,27 @@ struct AuraSaveStruct
     uint32 effIndexMask;
 };
 
+struct ScheduledTeleportData
+{
+    ScheduledTeleportData() : targetMapId(0), x(0.0f), y(0.0f), z(0.0f),
+        orientation(0.0f), options(0), recover(std::function<void()>()) {};
+
+    ScheduledTeleportData(uint32 mapid, float x, float y, float z, float o,
+        uint32 options, std::function<void()> recover)
+        : targetMapId(mapid), x(x), y(y), z(z),
+          orientation(o), options(options), recover(recover) {};
+
+    uint32 targetMapId;
+    float x;
+    float y;
+    float z;
+    float orientation;
+
+    uint32 options;
+
+    std::function<void()> recover;
+};
+
 class MANGOS_DLL_SPEC Player final: public Unit
 {
     friend class WorldSession;
@@ -860,6 +881,10 @@ class MANGOS_DLL_SPEC Player final: public Unit
         {
             return TeleportTo(loc.mapid, loc.coord_x, loc.coord_y, loc.coord_z, loc.orientation, options, recover);
         }
+
+        // _NOT_ thread-safe. Must be executed by the map manager after map updates, since we
+        // remove objects from the map
+        bool ExecuteTeleportFar(ScheduledTeleportData *data);
 
         bool TeleportToBGEntryPoint();
 

--- a/src/game/Objects/Player.h
+++ b/src/game/Objects/Player.h
@@ -1673,11 +1673,12 @@ class MANGOS_DLL_SPEC Player final: public Unit
         void learnSkillRewardedSpells(uint32 id, uint32 value);
 
         WorldLocation& GetTeleportDest() { return m_teleport_dest; }
-        bool IsBeingTeleported() const { return mSemaphoreTeleport_Near || mSemaphoreTeleport_Far; }
+        bool IsBeingTeleported() const { return mSemaphoreTeleport_Near || mSemaphoreTeleport_Far || mPendingFarTeleport; }
         bool IsBeingTeleportedNear() const { return mSemaphoreTeleport_Near; }
         bool IsBeingTeleportedFar() const { return mSemaphoreTeleport_Far; }
         void SetSemaphoreTeleportNear(bool semphsetting);
         void SetSemaphoreTeleportFar(bool semphsetting);
+        void SetPendingFarTeleport(bool pending) { mPendingFarTeleport = pending; }
         void ProcessDelayedOperations();
 
         void CheckAreaExploreAndOutdoor(void);
@@ -2419,6 +2420,7 @@ class MANGOS_DLL_SPEC Player final: public Unit
         std::function<void()> m_teleportRecoverDelayed;
         bool mSemaphoreTeleport_Near;
         bool mSemaphoreTeleport_Far;
+        bool mPendingFarTeleport;
 
         uint32 m_DelayedOperations;
         bool m_bCanDelayTeleport;

--- a/src/game/WorldSession.cpp
+++ b/src/game/WorldSession.cpp
@@ -678,12 +678,16 @@ void WorldSession::LogoutPlayer(bool Save)
             _player->TeleportToHomebind();
             //this is a bad place to call for far teleport because we need player to be in world for successful logout
             //maybe we should implement delayed far teleport logout?
+            sMapMgr.ExecuteSingleDelayedTeleport(_player);
         }
 
         // FG: finish pending transfers after starting the logout
         // this should fix players being able to logout and login back with full hp at death position
         while (_player->IsBeingTeleportedFar())
+        {
             HandleMoveWorldportAckOpcode();
+            sMapMgr.ExecuteSingleDelayedTeleport(_player); // Execute chain teleport if there are some
+        }
 
         // Refresh apres ca
         inWorld = _player->IsInWorld() && _player->FindMap();
@@ -731,6 +735,8 @@ void WorldSession::LogoutPlayer(bool Save)
                     removedFromMap = _player->TeleportTo(at->target_mapId, at->target_X, at->target_Y, at->target_Z, _player->GetOrientation());
                 else
                     removedFromMap = _player->TeleportToHomebind();
+
+                sMapMgr.ExecuteSingleDelayedTeleport(_player);
             }
         }
 


### PR DESCRIPTION
There exists a race condition where far teleports remove a player from a map during map update, but in functions that compare group members we liberally check IsInMap() and other world state related conditions, which is invalid usage. This can lead to a crash when we check IsInWorld() and then call something such as GetMap() when the unit was removed between the two calls