### PR TITLE
Implement restoration of deleted items.

### DIFF
--- a/sql/migrations/20171010065050_characters.sql
+++ b/sql/migrations/20171010065050_characters.sql
@@ -12,6 +12,7 @@ CREATE TABLE IF NOT EXISTS `character_deleted_items` (
   `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
   `player_guid` int(11) unsigned NOT NULL DEFAULT '0',
   `item_entry` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `stack_count` mediumint(8) unsigned NOT NULL DEFAULT '1',
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 

--- a/sql/migrations/20171010065050_characters.sql
+++ b/sql/migrations/20171010065050_characters.sql
@@ -1,0 +1,23 @@
+DROP PROCEDURE IF EXISTS add_migration;
+delimiter ??
+CREATE PROCEDURE `add_migration`()
+BEGIN
+DECLARE v INT DEFAULT 1;
+SET v = (SELECT COUNT(*) FROM `migrations` WHERE `id`='20171010065050');
+IF v=0 THEN
+INSERT INTO `migrations` VALUES ('20171010065050');
+-- Add your query below.
+
+CREATE TABLE IF NOT EXISTS `character_deleted_items` (
+  `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
+  `player_guid` int(11) unsigned NOT NULL DEFAULT '0',
+  `item_entry` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+
+-- End of migration.
+END IF;
+END??
+delimiter ; 
+CALL add_migration();
+DROP PROCEDURE IF EXISTS add_migration;

--- a/sql/migrations/20171010065050_world.sql
+++ b/sql/migrations/20171010065050_world.sql
@@ -1,0 +1,20 @@
+DROP PROCEDURE IF EXISTS add_migration;
+delimiter ??
+CREATE PROCEDURE `add_migration`()
+BEGIN
+DECLARE v INT DEFAULT 1;
+SET v = (SELECT COUNT(*) FROM `migrations` WHERE `id`='20171010065050');
+IF v=0 THEN
+INSERT INTO `migrations` VALUES ('20171010065050');
+-- Add your query below.
+
+
+INSERT INTO `mangos_string` (`entry`, `content_default`, `content_loc1`, `content_loc2`, `content_loc3`, `content_loc4`, `content_loc5`, `content_loc6`, `content_loc7`, `content_loc8`) VALUES (699, 'Dear player,\r\n\r\nPlease accept the item enclosed in this letter. It was removed from your character earlier because it should not have been available in the current patch, but our technicians have concluded that you may now have it back!', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+
+-- End of migration.
+END IF;
+END??
+delimiter ; 
+CALL add_migration();
+DROP PROCEDURE IF EXISTS add_migration;

--- a/src/game/Language.h
+++ b/src/game/Language.h
@@ -697,6 +697,7 @@ enum MangosStrings
     //LANG_BG_EY_DROPPED_FLAG           = 686,
     //LANG_BG_EY_RESETED_FLAG           = 687,
 
+    LANG_RESTORED_ITEM                  = 699,
     //LANG_ARENA_ONE_TOOLOW             = 700,
     //LANG_ARENA_ONE_MINUTE             = 701,
     //LANG_ARENA_THIRTY_SECONDS         = 702,

--- a/src/game/ObjectMgr.h
+++ b/src/game/ObjectMgr.h
@@ -1214,6 +1214,7 @@ class ObjectMgr
         void LoadFactionChangeItems();
         void LoadFactionChangeQuests();
         void LoadFactionChangeMounts();
+        void RestoreDeletedItems();
         bool GetMountDataByEntry(uint32 itemEntry, Races& race, uint8& mountNum) const;
         uint32 GetMountItemEntry(Races race, uint8 num) const;
         uint32 GetRandomMountForRace(Races race) const;

--- a/src/game/Objects/Player.cpp
+++ b/src/game/Objects/Player.cpp
@@ -14847,6 +14847,7 @@ void Player::_LoadInventory(QueryResult *result, uint32 timediff)
             {
                 CharacterDatabase.PExecute("DELETE FROM character_inventory WHERE item = '%u'", item_lowguid);
                 CharacterDatabase.PExecute("DELETE FROM item_instance WHERE guid = '%u'", item_lowguid);
+                CharacterDatabase.PExecute("INSERT INTO character_deleted_items (player_guid, item_entry) VALUES ('%u', '%u')", GetGUIDLow(), item_id);
                 sLog.outError("Player::_LoadInventory: Player %s has an unknown item (id: #%u) in inventory, deleted.", GetName(), item_id);
                 continue;
             }

--- a/src/game/Objects/Player.cpp
+++ b/src/game/Objects/Player.cpp
@@ -14847,7 +14847,7 @@ void Player::_LoadInventory(QueryResult *result, uint32 timediff)
             {
                 CharacterDatabase.PExecute("DELETE FROM character_inventory WHERE item = '%u'", item_lowguid);
                 CharacterDatabase.PExecute("DELETE FROM item_instance WHERE guid = '%u'", item_lowguid);
-                CharacterDatabase.PExecute("INSERT INTO character_deleted_items (player_guid, item_entry) VALUES ('%u', '%u')", GetGUIDLow(), item_id);
+                CharacterDatabase.PExecute("INSERT INTO character_deleted_items (player_guid, item_entry, stack_count) VALUES ('%u', '%u', '%u')", GetGUIDLow(), item_id, fields[2].GetUInt32());
                 sLog.outError("Player::_LoadInventory: Player %s has an unknown item (id: #%u) in inventory, deleted.", GetName(), item_id);
                 continue;
             }

--- a/src/game/World.cpp
+++ b/src/game/World.cpp
@@ -1617,6 +1617,9 @@ void World::SetInitialWorldSettings()
     sLog.outString("Loading spell group stack rules ...");
     sSpellMgr.LoadSpellGroupStackRules();
 
+    sLog.outString("Restoring deleted items to players ...");
+    sObjectMgr.RestoreDeletedItems();
+
     sAutoTestingMgr->Load();
 
     m_broadcaster =


### PR DESCRIPTION
When a player has an item that does not exist, it will now be saved in a new table called `character_deleted_items` so that those items may be restored at a later patch. The table is checked on server startup and items that exist in the current patch get sent to the player by mail.

![restored items](https://user-images.githubusercontent.com/6519171/31373064-4292cb40-ada1-11e7-8857-7a4c2b4d1844.jpg)

Now you can sleep sound knowing your contraband items that you should have never obtained in the first place are safe.