### PR TITLE
Fix Wrath of Cenarius proc.

### DIFF
--- a/src/game/Spells/Spell.cpp
+++ b/src/game/Spells/Spell.cpp
@@ -657,8 +657,8 @@ void Spell::prepareDataForTriggerSystem()
         switch (m_spellInfo->SpellFamilyName)
         {
             case SPELLFAMILY_MAGE:
-                // Blizzard triggers need do it
-                if (m_spellInfo->IsFitToFamilyMask<CF_MAGE_BLIZZARD>())
+                // Arcane Missiles / Blizzard triggers need do it
+                if (m_spellInfo->IsFitToFamilyMask(uint64(0x0000000000200080)))
                     m_canTrigger = true;
                 break;
             case SPELLFAMILY_WARLOCK:

--- a/src/game/UnitAuraProcHandler.cpp
+++ b/src/game/UnitAuraProcHandler.cpp
@@ -274,7 +274,13 @@ bool Unit::IsTriggeredAtSpellProcEvent(Unit *pVictim, SpellAuraHolder* holder, S
                 return true;
             return false;
         }
-
+        // Wrath of Cenarius - Spell Blasting
+        if (spellProto->Id == 25906)
+        {
+            // Should be able to proc on all magic damage.
+            if ((procSpell->DmgClass == SPELL_DAMAGE_CLASS_MAGIC) && !IsPositiveSpell(procSpell) && (procExtra & (PROC_EX_NORMAL_HIT | PROC_EX_CRITICAL_HIT)))
+                return roll_chance_f((float)spellProto->procChance);
+        }
         // DRUID
         // Omen of Clarity
         if (spellProto->Id == 16864)

--- a/src/game/UnitAuraProcHandler.cpp
+++ b/src/game/UnitAuraProcHandler.cpp
@@ -277,8 +277,8 @@ bool Unit::IsTriggeredAtSpellProcEvent(Unit *pVictim, SpellAuraHolder* holder, S
         // Wrath of Cenarius - Spell Blasting
         if (spellProto->Id == 25906)
         {
-            // Should be able to proc on all magic damage.
-            if ((procSpell->DmgClass == SPELL_DAMAGE_CLASS_MAGIC) && !IsPositiveSpell(procSpell) && (procExtra & (PROC_EX_NORMAL_HIT | PROC_EX_CRITICAL_HIT)))
+            // Should be able to proc when negative magical effect lands on a target.
+            if (!isVictim && (procSpell->DmgClass == SPELL_DAMAGE_CLASS_MAGIC) && !IsPositiveSpell(procSpell) && (procExtra & (PROC_EX_NORMAL_HIT | PROC_EX_CRITICAL_HIT)) && !(IsSpellAppliesAura(procSpell) && (procFlag & PROC_FLAG_ON_DO_PERIODIC)))
                 return roll_chance_f((float)spellProto->procChance);
         }
         // DRUID


### PR DESCRIPTION
Fixes issues https://github.com/elysium-project/server/issues/420, https://github.com/elysium-project/server/issues/2564, https://github.com/elysium-project/server/issues/2706.

This makes it so Wrath of Cenarius has a chance to proc every time consecration, arcane missiles or judgement deals damage. There is probably a much better way to fix it though. Its most likely a problem with how PROC_FLAG_SUCCESSFUL_NEGATIVE_SPELL_HIT works. I think those spells are supposed to have a chance to proc whenever any negative magical effect lands on a target.

If you search for spells with the same procflag as Wrath of Cenarius, you can see their descriptions support this:

> Mystical Disjunction
> Gives a chance **when your harmful spells land** to reduce the magical resistances of your spell targets by $25768s1 for $25768d.

> Engulfing Shadows
> Chance on **landing a damaging spell** to deal $27860s1 Shadow damage and restore $27860s2 mana to you.