### PR TITLE
Now always trigger on tick for positive periodic spells, regardless of target health

### DIFF
--- a/sql/migrations/20171013060930_world.sql
+++ b/sql/migrations/20171013060930_world.sql
@@ -1,0 +1,23 @@
+DROP PROCEDURE IF EXISTS add_migration;
+delimiter ??
+CREATE PROCEDURE `add_migration`()
+BEGIN
+DECLARE v INT DEFAULT 1;
+SET v = (SELECT COUNT(*) FROM `migrations` WHERE `id`='20171013060930');
+IF v=0 THEN
+INSERT INTO `migrations` VALUES ('20171013060930');
+
+-- Druid T3: Restore power on rejuv tick, only proc for period spells @ 50% chance per tick
+UPDATE `spell_proc_event` SET `procEx` = 0x0040000, `CustomChance` = 50 WHERE `entry` = 28716;
+
+-- Druid T3: Increase target HP with a stacking buff on regrowth tick and cast
+-- Proc for hit, crit and periodic ticks
+UPDATE `spell_proc_event` SET `procEx` = 0x0000001 | 0x0000002 | 0x0040000 WHERE `entry` = 28744;
+
+
+-- End of migration.
+END IF;
+END??
+delimiter ; 
+CALL add_migration();
+DROP PROCEDURE IF EXISTS add_migration;

--- a/src/game/UnitAuraProcHandler.cpp
+++ b/src/game/UnitAuraProcHandler.cpp
@@ -1556,6 +1556,32 @@ SpellAuraProcResult Unit::HandleOverrideClassScriptAuraProc(Unit *pVictim, uint3
                 triggered_spell_id = 23402;
             break;
         }
+        case 4533: // Druid T3 Bonus: 28716 (50% chance)
+        {
+            if (procSpell->IsFitToFamily<SPELLFAMILY_DRUID, CF_DRUID_REJUVENATION>())
+            {
+                switch (pVictim->getPowerType())
+                {
+                case POWER_MANA:
+                    triggered_spell_id = 28722;
+                    break;
+                case POWER_RAGE:
+                    triggered_spell_id = 28723;
+                    break;
+                case POWER_ENERGY:
+                    triggered_spell_id = 28724;
+                    break;
+                }
+            }
+            break;
+        }
+        case 4537: // Druid T3 Bonus: 28744
+        {
+            if (procSpell->IsFitToFamily<SPELLFAMILY_DRUID, CF_DRUID_REGROWTH>())
+                triggered_spell_id = 28750;
+
+            break;
+        }
     }
 
     // not processed


### PR DESCRIPTION
Not allowing ticks to trigger when the target is full health prevents things such as the Druid T3 bonuses and Hunter Mend Pet talents from proccing, which is clearly wrong behaviour. There are probably additional cases that this covers which should be triggering as well.

There were some other issues with Druid T3 set bonuses that have been resolved too, such as regrowth not triggering the 6-set proc on initial application. #2953